### PR TITLE
Add microseconds to start and end times

### DIFF
--- a/bin/viirs_dr_runner.py
+++ b/bin/viirs_dr_runner.py
@@ -46,7 +46,7 @@ from posttroll.message import Message
 
 import cspp_runner
 import cspp_runner.orbitno
-from cspp_runner import (get_datetime_from_filename, is_same_granule)
+from cspp_runner import (get_datetime_from_filename, get_sdr_times, is_same_granule)
 from cspp_runner.post_cspp import (get_sdr_files,
                                    create_subdirname,
                                    pack_sdr_files, make_okay_files,
@@ -301,21 +301,6 @@ def run_cspp(*viirs_rdr_files):
 
     viirs_sdr_proc.poll()
     return working_dir
-
-
-def get_sdr_times(filename):
-    """Get the start and end times from the SDR file name
-    """
-    bname = os.path.basename(filename)
-    sll = bname.split('_')
-    start_time = datetime.strptime(sll[2] + sll[3][:-1],
-                                   "d%Y%m%dt%H%M%S")
-    end_time = datetime.strptime(sll[2] + sll[4][:-1],
-                                 "d%Y%m%de%H%M%S")
-    if end_time < start_time:
-        end_time += timedelta(days=1)
-
-    return start_time, end_time
 
 
 def publish_sdr(publisher, result_files, mda, **kwargs):

--- a/cspp_runner/__init__.py
+++ b/cspp_runner/__init__.py
@@ -83,14 +83,24 @@ def _dte2time(date, start_time, end_time):
 
 
 def get_datetime_from_filename(filename):
-    """Get start observation time from the filename. Example:
+    """Get start observation time from the filename.
+
+    Example:
     'GMODO_npp_d20120405_t0037099_e0038341_b00001_c20120405124731856767_cspp_dev.h5'
     'SVM11_npp_d20180121_t0903382_e0905024_b32305_c20180121091145126446_cspp_dev.h5'
     """
+    return get_sdr_times(filename)[0]
 
-    bname = os.path.basename(filename)
-    sll = bname.split('_')
-    return datetime.strptime(sll[2] + sll[3][:-1], "d%Y%m%dt%H%M%S")
+def get_sdr_times(filename):
+    """Get the start and end times from the SDR file name."""
+    basename = os.path.basename(filename)
+    sll = basename.split('_')
+    start_time = datetime.strptime(sll[2] + sll[3], "d%Y%m%dt%H%M%S%f")
+    end_time = datetime.strptime(sll[2] + sll[4], "d%Y%m%de%H%M%S%f")
+    if end_time < start_time:
+        end_time += timedelta(days=1)
+
+    return start_time, end_time
 
 
 def is_same_granule(filename1, filename2, sec_tolerance):

--- a/cspp_runner/tests/__init__.py
+++ b/cspp_runner/tests/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020 Pytroll
+
+# Author(s):
+
+#   Martin.Raspaud <martin.raspaud@smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/cspp_runner/tests/test_utils.py
+++ b/cspp_runner/tests/test_utils.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020 Pytroll
+
+# Author(s):
+
+#   Martin.Raspaud <martin.raspaud@smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from cspp_runner import get_sdr_times, get_datetime_from_filename
+from datetime import datetime
+from unittest import TestCase
+
+
+class TestTimeExtraction(TestCase):
+
+    def test_get_sdr_times(self):
+        filename = 'GMODO_npp_d20120405_t0037099_e0038341_b00001_c20120405124731856767_cspp_dev.h5'
+        start_time, end_time = get_sdr_times(filename)
+        assert start_time == datetime(2012, 4, 5, 0, 37, 9, 900000)
+        assert end_time == datetime(2012, 4, 5, 0, 38, 34, 100000)
+
+    def test_get_sdr_times_over_midnight(self):
+        filename = 'GMODO_npp_d20120405_t2359099_e0000341_b00001_c20120405124731856767_cspp_dev.h5'
+        start_time, end_time = get_sdr_times(filename)
+        assert start_time == datetime(2012, 4, 5, 23, 59, 9, 900000)
+        assert end_time == datetime(2012, 4, 6, 0, 0, 34, 100000)
+        assert get_datetime_from_filename(filename) == start_time


### PR DESCRIPTION
The runner was leaving out the microseconds from the times. This PR fixes this.