### PR TITLE
Publish correct start time for whole overpass

### DIFF
--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -304,16 +304,22 @@ def publish_sdr(publisher, result_files, mda, site, mode,
         to_send["orbit_number"] = kwargs['orbit']
 
     to_send["dataset"] = []
+    start_times = set()
+    end_times = set()
     for result_file in result_files:
         filename = os.path.basename(result_file)
         to_send[
             'dataset'].append({'uri': urlunsplit(('ssh', socket.gethostname(),
                                                   result_file, '', '')),
                                'uid': filename})
+        (start_time, end_time) = get_sdr_times(filename)
+        start_times.add(start_time)
+        end_times.add(end_time)
     to_send['format'] = 'SDR'
     to_send['type'] = 'HDF5'
     to_send['data_processing_level'] = '1B'
-    to_send['start_time'], to_send['end_time'] = get_sdr_times(filename)
+    to_send['start_time'] = min(start_times)
+    to_send['end_time'] = max(end_times)
 
     LOG.debug('Site = %s', site)
     LOG.debug('Publish topic = %s', publish_topic)

--- a/cspp_runner/tests/test_runner.py
+++ b/cspp_runner/tests/test_runner.py
@@ -54,18 +54,19 @@ def fakemessage(fakefile):
 def fake_result_names(tmp_path):
     p = tmp_path / "results"
     all = []
-    for f in [
-            "SVM16_j01_d20211229_t1342527_e1344173_b21313_c20211229140342734674_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1344185_e1345430_b21313_c20211229140341407055_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1345442_e1347070_b21313_c20211229140319026930_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1347082_e1348327_b21313_c20211229140346771475_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1348340_e1349585_b21313_c20211229140336541537_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1349597_e1351242_b21313_c20211229140303590485_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1351255_e1352482_b21313_c20211229140800466176_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1352495_e1354140_b21313_c20211229142321678073_cspp_dev.h5",
-            "SVM16_j01_d20211229_t1354152_e1355397_b21313_c20211229142320304291_cspp_dev.h5"]:
-        new = p / f
-        all.append(new)
+    for lbl in ["GMTCO", "SVM02", "SVM09", "SVM10", "SVM12"]:
+        for f in [
+                f"{lbl:s}_j01_d20211229_t1342527_e1344173_b21313_c20211229140342734674_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1344185_e1345430_b21313_c20211229140341407055_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1345442_e1347070_b21313_c20211229140319026930_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1347082_e1348327_b21313_c20211229140346771475_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1348340_e1349585_b21313_c20211229140336541537_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1349597_e1351242_b21313_c20211229140303590485_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1351255_e1352482_b21313_c20211229140800466176_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1352495_e1354140_b21313_c20211229142321678073_cspp_dev.h5",
+                f"{lbl:s}_j01_d20211229_t1354152_e1355397_b21313_c20211229142320304291_cspp_dev.h5"]:
+            new = p / f
+            all.append(new)
     return all
 
 
@@ -264,7 +265,7 @@ def test_spawn_cspp_nominal(tmp_path, caplog, fake_result_names, monkeypatch):
             (wd, rf) = cspp_runner.runner.spawn_cspp(
                 os.fspath(
                     tmp_path /
-                    "RNSCA-RVIRS_j01_d20211221_t1436057_e1444378_b21199_c20211221144433345000_all-_dev.h5"),
+                    "RNSCA-RVIRS_j01_d20211229_t1342527_e1355397_b21199_c20211229144433345000_all-_dev.h5"),
                 viirs_sdr_call="touch",
                 viirs_sdr_options=[],
                 granule_time_tolerance=10)

--- a/cspp_runner/tests/test_runner.py
+++ b/cspp_runner/tests/test_runner.py
@@ -55,11 +55,15 @@ def fake_result_names(tmp_path):
     p = tmp_path / "results"
     all = []
     for f in [
-            "GMTCO_j01_d20211221_t1436067_e1437312_b21200_c20211221144949626416_cspp_dev.h5",
-            "SVM12_j01_d20211221_t1436067_e1437312_b21200_c20211221145100921548_cspp_dev.h5",
-            "SVM10_j01_d20211221_t1436067_e1437312_b21200_c20211221145100419360_cspp_dev.h5",
-            "SVM02_j01_d20211221_t1436067_e1437312_b21200_c20211221145058798219_cspp_dev.h5",
-            "SVM09_j01_d20211221_t1436067_e1437312_b21200_c20211221145100251266_cspp_dev.h5"]:
+            "SVM16_j01_d20211229_t1342527_e1344173_b21313_c20211229140342734674_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1344185_e1345430_b21313_c20211229140341407055_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1345442_e1347070_b21313_c20211229140319026930_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1347082_e1348327_b21313_c20211229140346771475_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1348340_e1349585_b21313_c20211229140336541537_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1349597_e1351242_b21313_c20211229140303590485_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1351255_e1352482_b21313_c20211229140800466176_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1352495_e1354140_b21313_c20211229142321678073_cspp_dev.h5",
+            "SVM16_j01_d20211229_t1354152_e1355397_b21313_c20211229142320304291_cspp_dev.h5"]:
         new = p / f
         all.append(new)
     return all
@@ -117,6 +121,8 @@ def test_publish(fake_results):
     assert msg.startswith(
             "pytroll://treasure/collected/complete/SDR/1B/wonderland"
             "/test/polar/direct_readout dataset")
+    assert '"end_time": "2021-12-29T13:55:39.700000"' in msg
+    assert '"start_time": "2021-12-29T13:42:52.700000"' in msg
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When publishing an SDR, make sure we publish the start and end time for the entire overpass, not just for the final file.

- [x] Fixes #3 
- [x] Tests added
- [x] Tests passed