### PR TITLE
add gdal to CI requirements

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -19,6 +19,7 @@ dependencies:
   - pytest-cov
   - appdirs
   - h5py
+  - gdal
   - pip
   - pip:
     - trollsift


### PR DESCRIPTION
Add gdal to CI requirements.  Maybe this will fix #18.

<!-- Describe what your PR does, and why -->

 - [ ] Closes #18 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest pyspectral`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
