### PR TITLE
More informative error message when not updating timestamp file

### DIFF
--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -190,8 +190,10 @@ def update_files(url_jpss_remote_dir, update_stampfile_prefix, mirror_jpss,
         try:
             fpt = open(filename, "w")
             fpt.write(timestamp)
-        except OSError:
-            LOG.warning(f'Failed to write {what:s}-update time-stamp file')
+        except OSError as e:
+            LOG.warning(
+                f'Failed to write {what:s}-update time-stamp file to '
+                f"{filename!s}: {e.args[1]:s}")
             return
         else:
             fpt.close()
@@ -292,11 +294,11 @@ def publish_sdr(publisher, result_files, mda, site, mode,
     to_send = mda.copy()
     # Delete the RDR uri and uid from the message:
     try:
-        del(to_send['uri'])
+        del to_send['uri']
     except KeyError:
         LOG.warning("Couldn't remove URI from message")
     try:
-        del(to_send['uid'])
+        del to_send['uid']
     except KeyError:
         LOG.warning("Couldn't remove UID from message")
 

--- a/cspp_runner/tests/test_runner.py
+++ b/cspp_runner/tests/test_runner.py
@@ -170,6 +170,22 @@ def test_update_nominal(monkeypatch, tmp_path, caplog, funcname, label):
 
 
 @pytest.mark.parametrize(
+        "funcname,label", [("update_lut_files", "LUT"),
+                           ("update_ancillary_files", "ANC")])
+def test_update_stampfile_fails(monkeypatch, tmp_path, caplog, funcname, label):
+    """Test update case when writing stampfile files."""
+    import cspp_runner.runner
+    updater = getattr(cspp_runner.runner, funcname)
+    monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
+    stampfile = os.fspath(tmp_path / "stampfile" / "directory" / "does" / "not" / "exist")
+    with caplog.at_level(logging.INFO):
+        updater("gopher://dummy/location", stampfile, "echo")
+    assert (f"Failed to write {label:s}-update time-stamp file to "
+            f"{stampfile:s}" in caplog.text)
+    assert "No such file or directory" in caplog.text
+
+
+@pytest.mark.parametrize(
         "funcname", ["update_lut_files", "update_ancillary_files"])
 def test_update_error(monkeypatch, tmp_path, caplog, funcname):
     """Check that a failed LUT update is logged to stderr.


### PR DESCRIPTION
Add a more informative error message when the timestamp file could not be updated.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest cspp_runner`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
