### PR TITLE
Bugfix - make sure messaging is done immediately after an SDR granule is ready!

### DIFF
--- a/cspp_runner/post_cspp.py
+++ b/cspp_runner/post_cspp.py
@@ -1,12 +1,15 @@
-"""Scanning the CSPP working directory and cleaning up after CSPP processing
-and move the SDR granules to a destination directory"""
+"""Various helper functions for re-organizing the CSPP results after processing.
+
+Scanning the CSPP working directory and cleaning up after CSPP processing
+and move the SDR granules to a destination directory.
+"""
 
 import os
-import pathlib
 import stat
-from datetime import datetime
+from datetime import datetime, timedelta
 import shutil
 from glob import glob
+from trollsift import Parser
 from cspp_runner.orbitno import TBUS_STYLE
 import logging
 LOG = logging.getLogger(__name__)
@@ -23,35 +26,46 @@ PLATFORM_NAME = {'Suomi-NPP': 'npp',
                  'NOAA-21': 'noaa21'}
 
 
-def cleanup_cspp_workdir(workdir):
-    """Clean up the CSPP working dir after processing"""
+VIIRS_SDR_FILE_PATTERN = '{dataset}_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}{msec_start}_e{end_time:%H%M%S}{msec_end}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_{source}.h5'  # noqa
 
-    filelist = glob('%s/*' % workdir)
+EXPECTED_NUMBER_OF_SDR_FILES = 28
+
+
+def cleanup_cspp_workdir(workdir):
+    """Clean up the CSPP working dir after processing."""
+    try:
+        filelist = workdir.glob('*')
+    except AttributeError:
+        filelist = glob('%s/*' % workdir)
+
     for s in filelist:
         if os.path.isfile(s):
             os.remove(s)
-    filelist = glob('%s/*' % workdir)
-    LOG.info(
-        "Number of items left after cleaning working dir = " + str(len(filelist)))
-    shutil.rmtree(workdir)
-    # os.mkdir(workdir)
+
+    try:
+        filelist = workdir.glob('*')
+    except AttributeError:
+        filelist = glob('%s/*' % workdir)
+
+    nfiles = len([f for f in filelist])
+    LOG.info("Number of items left after cleaning working dir = %d", nfiles)
     return
 
 
 def get_ivcdb_files(sdr_dir):
-    """Locate the ivcdb files need for the VIIRS Active Fires algorithm. These
-       files are not yet part of the standard output of CSPP versio 3.1 and
-       earlier. Use '-d' flag and locate the files in sub-directories
+    """Locate the ivcdb files needed for the VIIRS Active Fires algorithm.
 
+    Please observe: These files are not part of the standard output of CSPP
+    version 3.1 and earlier. Use '-d' flag and locate the files in
+    sub-directories.
     """
     # From the Active Fires Insuidetallation G:
     # find . -type f -name 'IVCDB*.h5' -exec mv {} ${PWD} \;
-
     import fnmatch
     import os
 
     matches = []
-    for root, dirnames, filenames in os.walk(sdr_dir):
+    for root, _, filenames in os.walk(sdr_dir):
         for filename in fnmatch.filter(filenames, 'IVCDB*.h5'):
             matches.append(os.path.join(root, filename))
 
@@ -59,27 +73,84 @@ def get_ivcdb_files(sdr_dir):
 
 
 def get_sdr_files(sdr_dir, **kwargs):
-    """Get the sdr filenames (all M- and I-bands plus geolocation for the
-    direct readout swath"""
+    """Get the sdr filenames (all M- and I-bands plus geolocation) for the direct readout swath."""
+    params = {}
+    params.update({'source': 'cspp_dev'})
+    params.update(kwargs)
+    # params.update({'start_time': kwargs.get('start_time')})
+    if 'start_time' in params and not params.get('start_time'):
+        params.pop('start_time')
+    params.update({'platform_short_name': PLATFORM_NAME.get(kwargs.get('platform_name'))})
+    try:
+        params.pop('platform_name')
+    except KeyError:
+        pass
 
-    # VIIRS M-bands + geolocation:
-    mband_files = (glob(os.path.join(sdr_dir, 'SVM??_???_*.h5')) +
-                   glob(os.path.join(sdr_dir, 'GM??O_???_*.h5')))
-    # VIIRS I-bands + geolocation:
-    iband_files = (glob(os.path.join(sdr_dir, 'SVI??_???_*.h5')) +
-                   glob(os.path.join(sdr_dir, 'GI??O_???_*.h5')))
-    # VIIRS DNB band + geolocation:
-    dnb_files = (glob(os.path.join(sdr_dir, 'SVDNB_???_*.h5')) +
-                 glob(os.path.join(sdr_dir, 'GDNBO_???_*.h5')))
+    time_tolerance = kwargs.get('time_tolerance', timedelta(seconds=0))
+    if 'start_time' not in params or time_tolerance.total_seconds() == 0:
+        sdr_files = get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params)
+        if len(sdr_files) < EXPECTED_NUMBER_OF_SDR_FILES:
+            LOG.error("No or not enough SDR files found matching the RDR granule: Files found = %s",
+                      str(sdr_files))
+        return sdr_files
 
-    ivcdb_files = get_ivcdb_files(sdr_dir)
+    sdr_files = get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params)
+    nfiles_found = len(sdr_files)
+    if nfiles_found >= EXPECTED_NUMBER_OF_SDR_FILES:
+        return sdr_files
+
+    start_time = params['start_time']
+    LOG.warning("No or not enough SDR files found matching the RDR granule: Files found = %d", nfiles_found)
+    LOG.info("Will look for SDR files with a start time close in time to the start time of the RDR granule.")
+    expected_start_time = start_time - time_tolerance
+    sdr_files = []
+    while nfiles_found < EXPECTED_NUMBER_OF_SDR_FILES and expected_start_time < start_time + time_tolerance:
+        params.update({'start_time': expected_start_time})
+        sdr_files = sdr_files + get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params)
+        nfiles_found = len(sdr_files)
+        expected_start_time = expected_start_time + timedelta(seconds=1)
+
+    # FIXME: Check for sufficient files an possibly raise an exception if not successful.
+    if nfiles_found == EXPECTED_NUMBER_OF_SDR_FILES:
+        LOG.debug("Expected number of SDR files found matching the RDR file.")
+    else:
+        LOG.error("Not enough SDR files found for the RDR scene: Files found = %d - Expected = %d",
+                  nfiles_found, EXPECTED_NUMBER_OF_SDR_FILES)
+
+    return sdr_files
+
+
+def get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params):
+    """From a list of file pattern inputs get the list of file names by globbing in a directory."""
+    p__ = Parser(VIIRS_SDR_FILE_PATTERN)
+
+    params.update({'dataset': 'SVM??'})
+    mband_files = [f for f in sdr_dir.glob(p__.globify(params))]
+    params.update({'dataset': 'GM??O'})
+    mband_files = mband_files + [f for f in sdr_dir.glob(p__.globify(params))]
+
+    params.update({'dataset': 'SVI??'})
+    iband_files = [f for f in sdr_dir.glob(p__.globify(params))]
+    params.update({'dataset': 'GI??O'})
+    iband_files = iband_files + [f for f in sdr_dir.glob(p__.globify(params))]
+
+    params.update({'dataset': 'SVDNB'})
+    dnb_files = [f for f in sdr_dir.glob(p__.globify(params))]
+    params.update({'dataset': 'GDNBO'})
+    dnb_files = dnb_files + [f for f in sdr_dir.glob(p__.globify(params))]
+
+    params.update({'dataset': 'IVCDB'})
+    ivcdb_files = [f for f in sdr_dir.glob(p__.globify(params))]
 
     return sorted(mband_files) + sorted(iband_files) + sorted(dnb_files) + sorted(ivcdb_files)
 
 
 def create_subdirname(obstime, with_seconds=False, **kwargs):
-    """Generate the pps subdirectory name from the start observation time, ex.:
-    'npp_20120405_0037_02270'"""
+    """Generate the pps subdirectory name from the start observation time.
+
+    For example:
+       'npp_20120405_0037_02270'
+    """
     sat = kwargs.get('platform_name', 'npp')
     platform_name = PLATFORM_NAME.get(sat, sat)
 
@@ -105,26 +176,16 @@ def create_subdirname(obstime, with_seconds=False, **kwargs):
         return platform_name + obstime.strftime('_%Y%m%d_%H%M_') + '%.5d' % orbnum
 
 
-def make_okay_files(base_dir, subdir_name):
-    """Make okay file to signal that all SDR files have been placed in
-    destination directory"""
-    import subprocess
-    okfile = os.path.join(base_dir, subdir_name + ".okay")
-    subprocess.call(['touch', okfile])
-    return
-
-
-def pack_sdr_files(sdrfiles, base_dir, subdir):
-    """Copy the SDR files to the sub-directory under the *subdir* directory
-    structure"""
-
-    path = pathlib.Path(base_dir) / subdir
-    path.mkdir(exist_ok=True, parents=True)
+# def pack_sdr_files(sdrfiles, base_dir, subdir):
+def pack_sdr_files(sdrfiles, dest_path):
+    """Copy the SDR files to the destination under the *subdir* directory structure."""
+    # path = pathlib.Path(base_dir) / subdir
+    dest_path.mkdir(exist_ok=True, parents=True)
 
     LOG.info("Number of SDR files: " + str(len(sdrfiles)))
     retvl = []
     for sdrfile in sdrfiles:
-        newfilename = path / os.path.basename(sdrfile)
+        newfilename = dest_path / os.path.basename(sdrfile)
         LOG.info(f"Copy sdrfile to destination: {newfilename!s}")
         if os.path.exists(sdrfile):
             LOG.info("File to copy: {file} <> ST_MTIME={time}".format(
@@ -159,4 +220,3 @@ if __name__ == "__main__":
 
     subd = create_subdirname(start_time)
     pack_sdr_files(FILES, rootdir, subd)
-    make_okay_files(rootdir, subd)

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -24,10 +24,8 @@ and trigger processing on direct readout RDR data (granules or full swaths).
 
 
 import os
-import socket
 import logging
 import multiprocessing
-import netifaces
 import pathlib
 import shutil
 import stat
@@ -38,7 +36,7 @@ import yaml
 from glob import glob
 from datetime import datetime, timedelta
 from multiprocessing.pool import ThreadPool
-from urllib.parse import urlunsplit, urlparse
+from urllib.parse import urlparse
 
 import posttroll.subscriber
 from posttroll.publisher import Publish
@@ -46,10 +44,10 @@ from posttroll.message import Message
 
 import cspp_runner
 import cspp_runner.orbitno
-from cspp_runner import (get_datetime_from_filename, get_sdr_times, is_same_granule)
+from cspp_runner import (get_datetime_from_filename, get_sdr_times)
 from cspp_runner.post_cspp import (get_sdr_files,
                                    create_subdirname,
-                                   pack_sdr_files, make_okay_files,
+                                   pack_sdr_files,
                                    cleanup_cspp_workdir)
 from cspp_runner.pre_cspp import fix_rdrfile
 
@@ -243,7 +241,7 @@ def update_ancillary_files(url_jpss_remote_anc_dir,
         timeout=timeout)
 
 
-def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
+def run_cspp(work_dir, viirs_sdr_call, viirs_sdr_options, viirs_rdr_files):
     """Run CSPP on VIIRS RDR files."""
     LOG.info("viirs_sdr_options = " + str(viirs_sdr_options))
     path = os.environ["PATH"]
@@ -252,11 +250,7 @@ def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
         LOG.warning("No options will be passed to CSPP")
         viirs_sdr_options = []
 
-    cspp_workdir = os.environ.get("CSPP_WORKDIR", '')
-    try:
-        working_dir = tempfile.mkdtemp(dir=cspp_workdir)
-    except OSError:
-        working_dir = tempfile.mkdtemp()
+    os.environ.update({"CSPP_WORKDIR": str(work_dir)})
 
     # Run the command:
     cmdlist = [viirs_sdr_call]
@@ -266,7 +260,7 @@ def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
     t0_wall = time.time()
     LOG.info("Popen call arguments: " + str(cmdlist))
     viirs_sdr_proc = subprocess.Popen(
-        cmdlist, cwd=working_dir,
+        cmdlist, cwd=str(work_dir),
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE)
     while True:
@@ -283,129 +277,26 @@ def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
 
     LOG.info("Seconds process time: " + (str(time.process_time() - t0_clock)))
     LOG.info("Seconds wall clock time: " + (str(time.time() - t0_wall)))
-
     viirs_sdr_proc.poll()
-    return working_dir
 
-
-def publish_sdr(publisher, result_files, mda, site, mode,
-                publish_topic, **kwargs):
-    """Publish the messages that SDR files are ready."""
-    if not result_files:
-        return
-
-    # Now publish:
-    to_send = mda.copy()
-    # Delete the RDR uri and uid from the message:
-    try:
-        del (to_send['uri'])
-    except KeyError:
-        LOG.warning("Couldn't remove URI from message")
-    try:
-        del (to_send['uid'])
-    except KeyError:
-        LOG.warning("Couldn't remove UID from message")
-
-    if 'orbit' in kwargs:
-        to_send["orig_orbit_number"] = to_send["orbit_number"]
-        to_send["orbit_number"] = kwargs['orbit']
-
-    to_send["dataset"] = []
-    start_times = set()
-    end_times = set()
-    for result_file in result_files:
-        filename = os.path.basename(result_file)
-        to_send[
-            'dataset'].append({'uri': urlunsplit(('ssh', socket.gethostname(),
-                                                  result_file, '', '')),
-                               'uid': filename})
-        (start_time, end_time) = get_sdr_times(filename)
-        start_times.add(start_time)
-        end_times.add(end_time)
-    to_send['format'] = 'SDR'
-    to_send['type'] = 'HDF5'
-    to_send['data_processing_level'] = '1B'
-    to_send['start_time'] = min(start_times)
-    to_send['end_time'] = max(end_times)
-
-    LOG.debug('Site = %s', site)
-    LOG.debug('Publish topic = %s', publish_topic)
-    msg = Message('/'.join(('',
-                            publish_topic,
-                            to_send['format'],
-                            to_send['data_processing_level'],
-                            site,
-                            mode,
-                            'polar',
-                            'direct_readout')),
-                  "dataset", to_send).encode()
-    LOG.debug("sending: " + str(msg))
-    publisher.send(msg)
-
-
-def spawn_cspp(current_granule, *glist, viirs_sdr_call, viirs_sdr_options, **kwargs):
-    """Spawn a CSPP run on the set of RDR files given."""
-    start_time = kwargs.get('start_time')
-    platform_name = kwargs.get('platform_name')
-
-    LOG.info("Start CSPP: RDR files = " + str(glist))
-    working_dir = run_cspp(viirs_sdr_call, viirs_sdr_options, *glist)
-    LOG.info("CSPP SDR processing finished...")
-    # Assume everything has gone well!
-    new_result_files = get_sdr_files(working_dir, platform_name=platform_name)
-    LOG.info("SDR file names: %s", str([os.path.basename(f) for f in new_result_files]))
-    if len(new_result_files) == 0:
-        LOG.warning("No SDR files available. CSPP probably failed!")
-        return working_dir, []
-
-    LOG.info("current_granule = " + str(current_granule))
-    LOG.info("glist = " + str(glist))
-    if current_granule in glist and len(glist) == 1:
-        LOG.info("Current granule is identical to the 'list of granules'" +
-                 " No sdr result files will be skipped")
-        return working_dir, new_result_files
-
-    # Only bother about the "current granule" - skip the rest
-    if start_time:
-        LOG.info("Start time of current granule (from messages): %s", start_time.strftime('%Y-%m-%d %H:%M'))
-
-    start_time = get_datetime_from_filename(current_granule)
-    LOG.info("Start time of current granule: %s", start_time.strftime('%Y-%m-%d %H:%M:%S'))
-    sec_tolerance = int(kwargs.get('granule_time_tolerance', 10))
-    LOG.info("Time tolerance to identify which SDR granule belong " +
-             "to the RDR granule being processed: " + str(sec_tolerance))
-    result_files = [new_file for new_file in new_result_files if is_same_granule(
-        current_granule, new_file, sec_tolerance)]
-
-    LOG.info("Number of results files = " + str(len(result_files)))
-    return working_dir, result_files
-
-
-def get_local_ips():
-    """Get the local IP address of where CSPP is running."""
-    inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
-                  for iface in netifaces.interfaces()]
-    ips = []
-    for addr in inet_addrs:
-        if addr is not None:
-            for add in addr:
-                ips.append(add['addr'])
-    return ips
+    return
 
 
 class ViirsSdrProcessor:
     """Container for the VIIRS SDR processing based on CSPP."""
 
-    def __init__(self, ncpus, level1_home):
+    def __init__(self, ncpus, level1_home, publish_topic):
         """Initialize the VIIRS processing class."""
         self.pool = ThreadPool(ncpus)
         self.ncpus = ncpus
+        self.publish_topic = publish_topic
 
-        self.orbit_number = 1  # Initialised orbit number
+        self.orbit_number = 0  # Initialised orbit number
         self.platform_name = 'unknown'  # Ex.: Suomi-NPP
         self.fullswath = False
         self.cspp_results = []
         self.glist = []
+        self.working_dir = None
         self.pass_start_time = None
         self.result_files = []
         self.sdr_home = level1_home
@@ -416,15 +307,14 @@ class ViirsSdrProcessor:
         self.fullswath = False
         self.cspp_results = []
         self.glist = []
+        self.working_dir = None
         self.pass_start_time = None
-        self.result_files = []
+        self.platform_name = 'unknown'
+        self.orbit_number = 0  # Initialised orbit number
+        # self.result_files = []
 
-    def pack_sdr_files(self, subd):
-        """Pack the SDR files together in one directory per pass."""
-        return pack_sdr_files(self.result_files, self.sdr_home, subd)
-
-    def run(self, msg, viirs_sdr_call, viirs_sdr_options,
-            granule_time_tolerance=10):
+    def run(self, msg, publisher, viirs_sdr_call, viirs_sdr_options,
+            granule_time_tolerance=10, granule_specific_working_dir=False):
         """Start the VIIRS SDR processing using CSPP on one rdr granule."""
         if msg:
             LOG.debug("Received message: " + str(msg))
@@ -437,12 +327,12 @@ class ViirsSdrProcessor:
             keeper = self.glist[1]
             LOG.info("Start CSPP: RDR files = " + str(self.glist))
             self.cspp_results.append(
-                self.pool.apply_async(
-                    spawn_cspp,
-                    [keeper] + self.glist,
-                    {"viirs_sdr_call": viirs_sdr_call,
-                     "viirs_sdr_options": viirs_sdr_options,
-                     "granule_time_tolerance": granule_time_tolerance}))
+                self.pool.apply_async(self.spawn_cspp,
+                                      args=(keeper, self.glist, publisher,
+                                            viirs_sdr_call,
+                                            viirs_sdr_options),
+                                      kwds={"granule_time_tolerance":
+                                            granule_time_tolerance}))
             LOG.debug("Inside run: Return with a False...")
             return False
         elif msg and ('platform_name' not in msg.data or 'sensor' not in msg.data):
@@ -460,16 +350,9 @@ class ViirsSdrProcessor:
         LOG.debug("\tMessage:")
         LOG.debug(str(msg))
         urlobj = urlparse(msg.data['uri'])
-        LOG.debug("Server = " + str(urlobj.netloc))
-        url_ip = socket.gethostbyname(urlobj.netloc)
-        if url_ip not in get_local_ips():
-            LOG.warning(
-                "Server %s not the current one: %s" % (str(urlobj.netloc),
-                                                       socket.gethostname()))
-
-        LOG.info("Ok... " + str(urlobj.netloc))
-        LOG.info("Sat and Instrument: " + str(msg.data['platform_name']) +
-                 " " + str(msg.data['sensor']))
+        LOG.info("Sat and Instrument: %s %s",
+                 str(msg.data['platform_name']),
+                 str(msg.data['sensor']))
 
         self.platform_name = str(msg.data['platform_name'])
         self.message_data = msg.data
@@ -494,27 +377,20 @@ class ViirsSdrProcessor:
 
         # Check if the file exists:
         if not os.path.exists(rdr_filename):
-            LOG.error("File is reported to be dispatched " +
-                      "but is not there! File = " +
-                      rdr_filename)
+            LOG.error("File is reported to be dispatched but is not there! File = %s", rdr_filename)
             return True
 
         # Do processing:
-        LOG.info("RDR to SDR processing on npp/viirs with CSPP start!" +
-                 " Start time = " + str(start_time))
-        LOG.info("File = %s" % str(rdr_filename))
+        LOG.info("VIIRS RDR to SDR processing with CSPP start! Start time = %s", str(start_time))
+        LOG.info("File = %s", str(rdr_filename))
         # Fix orbit number in RDR file:
         LOG.info("Fix orbit number in rdr file...")
         try:
             rdr_filename, orbnum = fix_rdrfile(rdr_filename)
         except IOError:
-            LOG.exception(
-                'Failed to fix orbit number in RDR file = ' +
-                str(urlobj.path))
+            LOG.exception('Failed to fix orbit number in RDR file = %s', str(urlobj.path))
         except cspp_runner.orbitno.NoTleFile:
-            LOG.exception(
-                'Failed to fix orbit number in RDR file = ' +
-                str(urlobj.path))
+            LOG.exception('Failed to fix orbit number in RDR file = %s', str(urlobj.path))
             LOG.error('No TLE file...')
         if orbnum:
             self.orbit_number = orbnum
@@ -548,27 +424,144 @@ class ViirsSdrProcessor:
                          " Continue")
                 return True
 
+        working_subdir_name = None
         start_time = get_datetime_from_filename(keeper)
         if self.pass_start_time is None:
             self.pass_start_time = start_time
-            LOG.debug("Set the start time of the entire swath: %s", self.pass_start_time.strftime('%Y-%m-%d %H:%M:%S'))
+            LOG.debug("Set the start time of the entire swath: %s",
+                      self.pass_start_time.strftime('%Y-%m-%d %H:%M:%S'))
+            # Create the name of the pass unique sub-directory (which will also
+            # be the working dir) if not already done:
+            working_subdir_name = create_subdirname(self.pass_start_time,
+                                                    platform_name=self.platform_name,
+                                                    orbit=self.orbit_number)
         else:
             LOG.debug("Start time of the entire swath is not changed")
+
+        # Get the default CSPP Working dir:
+        cspp_workdir = os.environ.get("CSPP_WORKDIR", '')
+
+        # Create the working directory if it doesn't exist already:
+        if not self.working_dir:
+            self.working_dir = pathlib.Path(self.sdr_home) / working_subdir_name
+            try:
+                self.working_dir.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                self.working_dir = pathlib.Path(tempfile.mkdtemp(dir=cspp_workdir))
+                LOG.warning("Failed creating the requested working directory path. created this instead: %s",
+                            self.working_dir)
 
         LOG.info("Before call to spawn_cspp. Argument list = " +
                  str([keeper] + self.glist))
         LOG.info("Start time: %s", start_time.strftime('%Y-%m-%d %H:%M:%S'))
         self.cspp_results.append(
-            self.pool.apply_async(
-                spawn_cspp,
-                [keeper] + self.glist,
-                {"viirs_sdr_call": viirs_sdr_call,
-                 "viirs_sdr_options": viirs_sdr_options}))
+            self.pool.apply_async(self.spawn_cspp,
+                                  args=(keeper, self.glist, publisher,
+                                        viirs_sdr_call,
+                                        viirs_sdr_options),
+                                  kwds={"granule_time_tolerance": granule_time_tolerance}))
+
         if self.fullswath:
             LOG.info("Full swath. Break granules loop")
             return False
 
         return True
+
+    def spawn_cspp(self, current_granule, glist, publisher,
+                   viirs_sdr_call, viirs_sdr_options, **kwargs):
+        """Spawn a CSPP run on the set of RDR files given."""
+        LOG.info("current_granule = " + str(current_granule))
+        LOG.info("glist = " + str(glist))
+        if current_granule in glist and len(glist) == 1:
+            LOG.info("Current granule is identical to the 'list of granules'" +
+                     " No sdr result files will be skipped")
+
+        start_time = get_datetime_from_filename(current_granule)
+        LOG.info("Start time of current granule: %s", start_time.strftime('%Y-%m-%d %H:%M:%S'))
+        sec_tolerance = int(kwargs.get('granule_time_tolerance', 10))
+        LOG.info("Time tolerance to identify which SDR granule belong " +
+                 "to the RDR granule being processed: " + str(sec_tolerance))
+
+        working_dir = pathlib.Path(tempfile.mkdtemp(dir=self.working_dir))
+
+        LOG.info("Start CSPP: RDR files = " + str(glist))
+        LOG.info("Run from working dir = %s", working_dir)
+        run_cspp(working_dir, viirs_sdr_call, viirs_sdr_options, *glist)
+        LOG.info("CSPP SDR processing finished...")
+        # Assume everything has gone well!
+        new_result_files = get_sdr_files(working_dir,
+                                         platform_name=self.platform_name,
+                                         start_time=start_time,
+                                         time_tolerance=timedelta(seconds=sec_tolerance))
+        if len(new_result_files) == 0:
+            LOG.warning("No SDR files available. CSPP probably failed!")
+            return []
+
+        LOG.info("Move the sdr files to the final destination: %s", self.working_dir)
+        new_result_files = pack_sdr_files(new_result_files, self.working_dir)
+
+        LOG.info("SDR file names: %s", str([os.path.basename(f) for f in new_result_files]))
+        LOG.info("Number of SDR results files = " + str(len(new_result_files)))
+        # Now start publish the files:
+        self.publish_sdr(publisher, new_result_files)
+
+        # Cleanup the working dir:
+        if working_dir != self.working_dir:
+            LOG.info("Clean the working directory: %s", str(working_dir))
+            cleanup_cspp_workdir(working_dir)
+
+        LOG.debug("Return all SDR result files.")
+        return new_result_files
+
+    def publish_sdr(self, publisher, result_files):
+        """Publish the messages that SDR files are ready."""
+        if not result_files:
+            return
+
+        # Now publish:
+        to_send = self.message_data.copy()
+        # Delete the RDR uri and uid from the message:
+        try:
+            del (to_send['uri'])
+        except KeyError:
+            LOG.warning("Couldn't remove URI from message")
+        try:
+            del (to_send['uid'])
+        except KeyError:
+            LOG.warning("Couldn't remove UID from message")
+
+        if self.orbit_number > 0:
+            to_send["orig_orbit_number"] = to_send["orbit_number"]
+            to_send["orbit_number"] = self.orbit_number
+
+        to_send["dataset"] = []
+        start_times = set()
+        end_times = set()
+
+        for result_file in result_files:
+            filename = os.path.basename(result_file)
+            to_send['dataset'].append({'uri': str(result_file), 'uid': filename})
+            (start_time, end_time) = get_sdr_times(filename)
+            start_times.add(start_time)
+            end_times.add(end_time)
+
+        to_send['format'] = 'SDR'
+        to_send['type'] = 'HDF5'
+        to_send['data_processing_level'] = '1B'
+        to_send['start_time'] = min(start_times)
+        to_send['end_time'] = max(end_times)
+
+        LOG.debug('Publish topic = %s', self.publish_topic)
+        msg = Message('/'.join(('',
+                                self.publish_topic,
+                                to_send['format'],
+                                to_send['data_processing_level'],
+                                'polar',
+                               'direct_readout')),
+                      "dataset", to_send).encode()
+        LOG.debug("sending: " + str(msg))
+        publisher.send(msg)
+        LOG.debug("After having published/sent message.")
 
 
 def npp_rolling_runner(
@@ -582,8 +575,6 @@ def npp_rolling_runner(
         anc_update_stampfile_prefix,
         mirror_jpss_ancillary,
         subscribe_topics,
-        site,
-        mode,
         publish_topic,
         level1_home,
         viirs_sdr_call,
@@ -638,46 +629,36 @@ def npp_rolling_runner(
                                         subscribe_topics, True) as subscr:
         with Publish(**pubconf) as publisher:
             while True:
+                LOG.debug("Re-initialise the viirs processor instance.")
                 viirs_proc.initialise()
                 for msg in subscr.recv(timeout=300):
                     status = viirs_proc.run(
-                        msg, viirs_sdr_call, viirs_sdr_options,
+                        msg, publisher,
+                        viirs_sdr_call, viirs_sdr_options,
                         granule_time_tolerance)
                     LOG.debug("Sent message to run: %s", str(msg))
-                    LOG.debug("Status: %s", str(status))
+                    LOG.debug("Running: %s", str(status))
                     if not status:
                         break  # end the loop and reinitialize !
 
-                LOG.debug(
-                    "Received message data = %s", str(viirs_proc.message_data))
-                proc_start_time = datetime.utcnow()
-                tobj = viirs_proc.pass_start_time
-                LOG.info("Time used in sub-dir name: " +
-                         str(tobj.strftime("%Y-%m-%d %H:%M")))
-                subd = create_subdirname(tobj, platform_name=viirs_proc.platform_name,
-                                         orbit=viirs_proc.orbit_number)
-                LOG.info("Create sub-directory for sdr files: %s" % str(subd))
+                if viirs_proc.pass_start_time:
+                    LOG.info("Seconds since granule start: {:.1f}".format(
+                        (datetime.utcnow() - viirs_proc.pass_start_time).total_seconds()))
+                else:
+                    LOG.debug("No start time for overpass set.")
+                    continue
 
-                LOG.info("Get the results from the multiprocessing pool-run")
+                LOG.info("No new rdr granules coming in anymore...")
+                LOG.debug("Get the results from the multiprocessing pool-run")
                 for res in viirs_proc.cspp_results:
-                    working_dir, tmp_result_files = res.get()
-                    viirs_proc.result_files = tmp_result_files
-                    sdr_files = viirs_proc.pack_sdr_files(subd)
-                    LOG.info("Cleaning up directory %s" % working_dir)
-                    cleanup_cspp_workdir(working_dir)
-                    publish_sdr(publisher, sdr_files,
-                                viirs_proc.message_data,
-                                site, mode, publish_topic,
-                                orbit=viirs_proc.orbit_number)
+                    result_files = res.get()
+                    if len(result_files) > 0:
+                        LOG.debug("Results on a granule ready. Number of files = %d. First file = %s",
+                                  len(result_files), result_files[0])
+                    else:
+                        LOG.error("Results on a granule ready, but no SDR files!")
 
-                make_okay_files(viirs_proc.sdr_home, subd)
-
-                LOG.info("Seconds to process SDR: {:.1f}".format(
-                    (datetime.utcnow() - proc_start_time).total_seconds()))
-                LOG.info("Seconds since granule start: {:.1f}".format(
-                    (datetime.utcnow() - tobj).total_seconds()))
-                LOG.info("Now that SDR processing has completed, " +
-                         "check for new LUT files...")
+                LOG.info("Now that SDR processing has completed, check for new LUT files...")
                 fresh = check_lut_files(
                     thr_lut_files_age_days, url_download_trial_frequency_hours,
                     lut_update_stampfile_prefix, lut_dir)

--- a/cspp_runner/viirs_dr_runner.py
+++ b/cspp_runner/viirs_dr_runner.py
@@ -94,8 +94,6 @@ def main():
     subscribe_topics = OPTIONS.get('subscribe_topics').split(',')
     subscribe_topics = [topic for topic in subscribe_topics if topic]
 
-    site = OPTIONS.get('site')
-
     thr_lut_files_age_days = OPTIONS.get('threshold_lut_files_age_days', 14)
     url_jpss_remote_lut_dir = OPTIONS['url_jpss_remote_lut_dir']
     url_jpss_remote_anc_dir = OPTIONS['url_jpss_remote_anc_dir']
@@ -138,8 +136,6 @@ def main():
         anc_update_stampfile_prefix,
         OPTIONS.get("mirror_jpss_ancillary"),
         subscribe_topics,
-        site,
-        OPTIONS["mode"],
         publish_topic,
         OPTIONS["level1_home"],
         viirs_sdr_call,


### PR DESCRIPTION


Clean up, re-factor and fix so messages are being sent immediately when SDR granule is ready

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest cspp_runner`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
