### PR TITLE
Bugfix - make sure messaging is done immediately after an SDR granule is ready

### DIFF
--- a/cspp_runner/post_cspp.py
+++ b/cspp_runner/post_cspp.py
@@ -16,12 +16,14 @@ LOG = logging.getLogger(__name__)
 
 TLE_SATNAME = {'npp': 'SUOMI NPP',
                'j01': 'NOAA-20',
+               'j02': 'NOAA-21',
                'noaa20': 'NOAA-20',
-               'noaa21': 'NOAA-20'
+               'noaa21': 'NOAA-21'
                }
 
 PLATFORM_NAME = {'Suomi-NPP': 'npp',
                  'JPSS-1': 'noaa20',
+                 'JPSS-2': 'noaa21',
                  'NOAA-20': 'noaa20',
                  'NOAA-21': 'noaa21'}
 

--- a/cspp_runner/post_cspp.py
+++ b/cspp_runner/post_cspp.py
@@ -1,12 +1,15 @@
-"""Scanning the CSPP working directory and cleaning up after CSPP processing
-and move the SDR granules to a destination directory"""
+"""Various helper functions for re-organizing the CSPP results after processing.
+
+Scanning the CSPP working directory and cleaning up after CSPP processing
+and move the SDR granules to a destination directory.
+"""
 
 import os
-import pathlib
 import stat
-from datetime import datetime
+from datetime import datetime, timedelta
 import shutil
 from glob import glob
+from trollsift import Parser
 from cspp_runner.orbitno import TBUS_STYLE
 import logging
 LOG = logging.getLogger(__name__)
@@ -23,35 +26,46 @@ PLATFORM_NAME = {'Suomi-NPP': 'npp',
                  'NOAA-21': 'noaa21'}
 
 
-def cleanup_cspp_workdir(workdir):
-    """Clean up the CSPP working dir after processing"""
+VIIRS_SDR_FILE_PATTERN = '{dataset}_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}{msec_start}_e{end_time:%H%M%S}{msec_end}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_{source}.h5'  # noqa
 
-    filelist = glob('%s/*' % workdir)
+EXPECTED_NUMBER_OF_SDR_FILES = 28
+
+
+def cleanup_cspp_workdir(workdir):
+    """Clean up the CSPP working dir after processing."""
+    try:
+        filelist = workdir.glob('*')
+    except AttributeError:
+        filelist = glob('%s/*' % workdir)
+
     for s in filelist:
         if os.path.isfile(s):
             os.remove(s)
-    filelist = glob('%s/*' % workdir)
-    LOG.info(
-        "Number of items left after cleaning working dir = " + str(len(filelist)))
-    shutil.rmtree(workdir)
-    # os.mkdir(workdir)
+
+    try:
+        filelist = workdir.glob('*')
+    except AttributeError:
+        filelist = glob('%s/*' % workdir)
+
+    nfiles = len([f for f in filelist])
+    LOG.info("Number of items left after cleaning working dir = %d", nfiles)
     return
 
 
 def get_ivcdb_files(sdr_dir):
-    """Locate the ivcdb files need for the VIIRS Active Fires algorithm. These
-       files are not yet part of the standard output of CSPP versio 3.1 and
-       earlier. Use '-d' flag and locate the files in sub-directories
+    """Locate the ivcdb files needed for the VIIRS Active Fires algorithm.
 
+    Please observe: These files are not part of the standard output of CSPP
+    version 3.1 and earlier. Use '-d' flag and locate the files in
+    sub-directories.
     """
     # From the Active Fires Insuidetallation G:
     # find . -type f -name 'IVCDB*.h5' -exec mv {} ${PWD} \;
-
     import fnmatch
     import os
 
     matches = []
-    for root, dirnames, filenames in os.walk(sdr_dir):
+    for root, _, filenames in os.walk(sdr_dir):
         for filename in fnmatch.filter(filenames, 'IVCDB*.h5'):
             matches.append(os.path.join(root, filename))
 
@@ -59,27 +73,84 @@ def get_ivcdb_files(sdr_dir):
 
 
 def get_sdr_files(sdr_dir, **kwargs):
-    """Get the sdr filenames (all M- and I-bands plus geolocation for the
-    direct readout swath"""
+    """Get the sdr filenames (all M- and I-bands plus geolocation) for the direct readout swath."""
+    params = {}
+    params.update({'source': 'cspp_dev'})
+    params.update(kwargs)
+    # params.update({'start_time': kwargs.get('start_time')})
+    if 'start_time' in params and not params.get('start_time'):
+        params.pop('start_time')
+    params.update({'platform_short_name': PLATFORM_NAME.get(kwargs.get('platform_name'))})
+    try:
+        params.pop('platform_name')
+    except KeyError:
+        pass
 
-    # VIIRS M-bands + geolocation:
-    mband_files = (glob(os.path.join(sdr_dir, 'SVM??_???_*.h5')) +
-                   glob(os.path.join(sdr_dir, 'GM??O_???_*.h5')))
-    # VIIRS I-bands + geolocation:
-    iband_files = (glob(os.path.join(sdr_dir, 'SVI??_???_*.h5')) +
-                   glob(os.path.join(sdr_dir, 'GI??O_???_*.h5')))
-    # VIIRS DNB band + geolocation:
-    dnb_files = (glob(os.path.join(sdr_dir, 'SVDNB_???_*.h5')) +
-                 glob(os.path.join(sdr_dir, 'GDNBO_???_*.h5')))
+    time_tolerance = kwargs.get('time_tolerance', timedelta(seconds=0))
+    if 'start_time' not in params or time_tolerance.total_seconds() == 0:
+        sdr_files = get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params)
+        if len(sdr_files) < EXPECTED_NUMBER_OF_SDR_FILES:
+            LOG.error("No or not enough SDR files found matching the RDR granule: Files found = %s",
+                      str(sdr_files))
+        return sdr_files
 
-    ivcdb_files = get_ivcdb_files(sdr_dir)
+    sdr_files = get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params)
+    nfiles_found = len(sdr_files)
+    if nfiles_found >= EXPECTED_NUMBER_OF_SDR_FILES:
+        return sdr_files
+
+    start_time = params['start_time']
+    LOG.warning("No or not enough SDR files found matching the RDR granule: Files found = %d", nfiles_found)
+    LOG.info("Will look for SDR files with a start time close in time to the start time of the RDR granule.")
+    expected_start_time = start_time - time_tolerance
+    sdr_files = []
+    while nfiles_found < EXPECTED_NUMBER_OF_SDR_FILES and expected_start_time < start_time + time_tolerance:
+        params.update({'start_time': expected_start_time})
+        sdr_files = sdr_files + get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params)
+        nfiles_found = len(sdr_files)
+        expected_start_time = expected_start_time + timedelta(seconds=1)
+
+    # FIXME: Check for sufficient files an possibly raise an exception if not successful.
+    if nfiles_found == EXPECTED_NUMBER_OF_SDR_FILES:
+        LOG.debug("Expected number of SDR files found matching the RDR file.")
+    else:
+        LOG.error("Not enough SDR files found for the RDR scene: Files found = %d - Expected = %d",
+                  nfiles_found, EXPECTED_NUMBER_OF_SDR_FILES)
+
+    return sdr_files
+
+
+def get_sdr_filenames_from_pattern_and_parameters(sdr_dir, params):
+    """From a list of file pattern inputs get the list of file names by globbing in a directory."""
+    p__ = Parser(VIIRS_SDR_FILE_PATTERN)
+
+    params.update({'dataset': 'SVM??'})
+    mband_files = [f for f in sdr_dir.glob(p__.globify(params))]
+    params.update({'dataset': 'GM??O'})
+    mband_files = mband_files + [f for f in sdr_dir.glob(p__.globify(params))]
+
+    params.update({'dataset': 'SVI??'})
+    iband_files = [f for f in sdr_dir.glob(p__.globify(params))]
+    params.update({'dataset': 'GI??O'})
+    iband_files = iband_files + [f for f in sdr_dir.glob(p__.globify(params))]
+
+    params.update({'dataset': 'SVDNB'})
+    dnb_files = [f for f in sdr_dir.glob(p__.globify(params))]
+    params.update({'dataset': 'GDNBO'})
+    dnb_files = dnb_files + [f for f in sdr_dir.glob(p__.globify(params))]
+
+    params.update({'dataset': 'IVCDB'})
+    ivcdb_files = [f for f in sdr_dir.glob(p__.globify(params))]
 
     return sorted(mband_files) + sorted(iband_files) + sorted(dnb_files) + sorted(ivcdb_files)
 
 
 def create_subdirname(obstime, with_seconds=False, **kwargs):
-    """Generate the pps subdirectory name from the start observation time, ex.:
-    'npp_20120405_0037_02270'"""
+    """Generate the pps subdirectory name from the start observation time.
+
+    For example:
+       'npp_20120405_0037_02270'
+    """
     sat = kwargs.get('platform_name', 'npp')
     platform_name = PLATFORM_NAME.get(sat, sat)
 
@@ -105,26 +176,16 @@ def create_subdirname(obstime, with_seconds=False, **kwargs):
         return platform_name + obstime.strftime('_%Y%m%d_%H%M_') + '%.5d' % orbnum
 
 
-def make_okay_files(base_dir, subdir_name):
-    """Make okay file to signal that all SDR files have been placed in
-    destination directory"""
-    import subprocess
-    okfile = os.path.join(base_dir, subdir_name + ".okay")
-    subprocess.call(['touch', okfile])
-    return
-
-
-def pack_sdr_files(sdrfiles, base_dir, subdir):
-    """Copy the SDR files to the sub-directory under the *subdir* directory
-    structure"""
-
-    path = pathlib.Path(base_dir) / subdir
-    path.mkdir(exist_ok=True, parents=True)
+# def pack_sdr_files(sdrfiles, base_dir, subdir):
+def pack_sdr_files(sdrfiles, dest_path):
+    """Copy the SDR files to the destination under the *subdir* directory structure."""
+    # path = pathlib.Path(base_dir) / subdir
+    dest_path.mkdir(exist_ok=True, parents=True)
 
     LOG.info("Number of SDR files: " + str(len(sdrfiles)))
     retvl = []
     for sdrfile in sdrfiles:
-        newfilename = path / os.path.basename(sdrfile)
+        newfilename = dest_path / os.path.basename(sdrfile)
         LOG.info(f"Copy sdrfile to destination: {newfilename!s}")
         if os.path.exists(sdrfile):
             LOG.info("File to copy: {file} <> ST_MTIME={time}".format(
@@ -159,4 +220,3 @@ if __name__ == "__main__":
 
     subd = create_subdirname(start_time)
     pack_sdr_files(FILES, rootdir, subd)
-    make_okay_files(rootdir, subd)

--- a/cspp_runner/post_cspp.py
+++ b/cspp_runner/post_cspp.py
@@ -176,10 +176,8 @@ def create_subdirname(obstime, with_seconds=False, **kwargs):
         return platform_name + obstime.strftime('_%Y%m%d_%H%M_') + '%.5d' % orbnum
 
 
-# def pack_sdr_files(sdrfiles, base_dir, subdir):
 def pack_sdr_files(sdrfiles, dest_path):
     """Copy the SDR files to the destination under the *subdir* directory structure."""
-    # path = pathlib.Path(base_dir) / subdir
     dest_path.mkdir(exist_ok=True, parents=True)
 
     LOG.info("Number of SDR files: " + str(len(sdrfiles)))

--- a/cspp_runner/post_cspp.py
+++ b/cspp_runner/post_cspp.py
@@ -40,6 +40,8 @@ def cleanup_cspp_workdir(workdir):
 
     for s in filelist:
         if os.path.isfile(s):
+            if s.name.find('SVM16') >= 0:
+                LOG.debug("Granule SDR %s will be cleaned", s.name)
             os.remove(s)
 
     try:
@@ -79,6 +81,7 @@ def get_sdr_files(sdr_dir, **kwargs):
     params.update(kwargs)
     # params.update({'start_time': kwargs.get('start_time')})
     if 'start_time' in params and not params.get('start_time'):
+        LOG.debug("params['start_time'] = %s", str(params['start_time']))
         params.pop('start_time')
     params.update({'platform_short_name': PLATFORM_NAME.get(kwargs.get('platform_name'))})
     try:
@@ -101,7 +104,8 @@ def get_sdr_files(sdr_dir, **kwargs):
 
     start_time = params['start_time']
     LOG.warning("No or not enough SDR files found matching the RDR granule: Files found = %d", nfiles_found)
-    LOG.info("Will look for SDR files with a start time close in time to the start time of the RDR granule.")
+    LOG.info("Will look for SDR files with a start time close in time to the start time of the RDR granule: %s",
+             str(start_time))
     expected_start_time = start_time - time_tolerance
     sdr_files = []
     while nfiles_found < EXPECTED_NUMBER_OF_SDR_FILES and expected_start_time < start_time + time_tolerance:
@@ -110,7 +114,7 @@ def get_sdr_files(sdr_dir, **kwargs):
         nfiles_found = len(sdr_files)
         expected_start_time = expected_start_time + timedelta(seconds=1)
 
-    # FIXME: Check for sufficient files an possibly raise an exception if not successful.
+    # FIXME: Check for sufficient files and possibly raise an exception if not successful.
     if nfiles_found == EXPECTED_NUMBER_OF_SDR_FILES:
         LOG.debug("Expected number of SDR files found matching the RDR file.")
     else:

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -482,13 +482,14 @@ class ViirsSdrProcessor:
         LOG.info("Time tolerance to identify which SDR granule belong " +
                  "to the RDR granule being processed: " + str(sec_tolerance))
 
-        working_dir = pathlib.Path(tempfile.mkdtemp(dir=self.working_dir))
+        working_dir = create_tmp_workdir(self.working_dir)
 
         LOG.info("Start CSPP: RDR files = " + str(glist))
         LOG.info("Run from working dir = %s", working_dir)
-        run_cspp(working_dir, viirs_sdr_call, viirs_sdr_options, *glist)
+        run_cspp(working_dir, viirs_sdr_call, viirs_sdr_options, glist)
         LOG.info("CSPP SDR processing finished...")
         # Assume everything has gone well!
+
         new_result_files = get_sdr_files(working_dir,
                                          platform_name=self.platform_name,
                                          start_time=start_time,
@@ -564,6 +565,11 @@ class ViirsSdrProcessor:
         LOG.debug("After having published/sent message.")
 
 
+def create_tmp_workdir(parrent_dir):
+    """Create unique temporary working dir."""
+    return pathlib.Path(tempfile.mkdtemp(dir=parrent_dir))
+
+
 def npp_rolling_runner(
         thr_lut_files_age_days,
         url_download_trial_frequency_hours,
@@ -616,7 +622,7 @@ def npp_rolling_runner(
     ncpus_available = multiprocessing.cpu_count()
     LOG.info("Number of CPUs available = " + str(ncpus_available))
     LOG.info("Will use %d CPUs when running CSPP instances" % ncpus)
-    viirs_proc = ViirsSdrProcessor(ncpus, level1_home)
+    viirs_proc = ViirsSdrProcessor(ncpus, level1_home, publish_topic)
 
     if publisher_config is None:
         pubconf = {"name": "viirs_dr_runner", "port": 0}

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -48,7 +48,8 @@ from cspp_runner import (get_datetime_from_filename, get_sdr_times)
 from cspp_runner.post_cspp import (get_sdr_files,
                                    create_subdirname,
                                    pack_sdr_files,
-                                   cleanup_cspp_workdir)
+                                   cleanup_cspp_workdir,
+                                   EXPECTED_NUMBER_OF_SDR_FILES)
 from cspp_runner.pre_cspp import fix_rdrfile
 
 PATH = os.environ.get('PATH', '')
@@ -503,8 +504,11 @@ class ViirsSdrProcessor:
 
         LOG.info("SDR file names: %s", str([os.path.basename(f) for f in new_result_files]))
         LOG.info("Number of SDR results files = " + str(len(new_result_files)))
-        # Now start publish the files:
-        self.publish_sdr(publisher, new_result_files)
+        if len(new_result_files) < EXPECTED_NUMBER_OF_SDR_FILES:
+            LOG.error("Less SDR files for granule than expected. CSPP probably failed, don't publish the result!")
+        else:
+            # Now start publish the files:
+            self.publish_sdr(publisher, new_result_files)
 
         # Cleanup the working dir:
         if working_dir != self.working_dir:

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -322,6 +322,8 @@ class ViirsSdrProcessor:
         """Start the VIIRS SDR processing using CSPP on one rdr granule."""
         if msg:
             LOG.debug("Received message: " + str(msg))
+        else:
+            LOG.debug("Message is None!")
 
         LOG.debug("glist: " + str(self.glist))
         if msg is None and self.glist and len(self.glist) > 2:
@@ -644,7 +646,7 @@ def npp_rolling_runner(
             while True:
                 LOG.debug("Re-initialise the viirs processor instance.")
                 viirs_proc.initialise()
-                for msg in subscr.recv(timeout=300):
+                for msg in subscr.recv(timeout=90):
                     status = viirs_proc.run(
                         msg, publisher,
                         viirs_sdr_call, viirs_sdr_options,

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -35,7 +35,7 @@ import time
 import yaml
 from glob import glob
 from datetime import datetime, timedelta
-from multiprocessing.pool import Pool
+from multiprocessing.pool import ThreadPool
 from urllib.parse import urlparse
 
 import posttroll.subscriber
@@ -291,8 +291,7 @@ class ViirsSdrProcessor:
 
     def __init__(self, ncpus, level1_home, publish_topic):
         """Initialize the VIIRS processing class."""
-        # self.pool = ThreadPool(ncpus)
-        self.pool = Pool(ncpus)
+        self.pool = ThreadPool(ncpus)
         self.ncpus = ncpus
         self.publish_topic = publish_topic
 

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -256,11 +256,13 @@ def run_cspp(work_dir, viirs_sdr_call, viirs_sdr_options, viirs_rdr_files):
     # Run the command:
     cmdlist = [viirs_sdr_call]
     cmdlist.extend(viirs_sdr_options)
-    list_of_filepaths = [str(rdr) for rdr in [viirs_rdr_files]]
+    list_of_filepaths = [str(rdr) for rdr in viirs_rdr_files]
+    LOG.info("Run CSPP on %d RDR file(s): %s", len(list_of_filepaths), str(list_of_filepaths))
     cmdlist.extend(list_of_filepaths)
+
     t0_clock = time.process_time()
     t0_wall = time.time()
-    LOG.info("Popen call arguments: " + str(cmdlist))
+    LOG.debug("Popen call arguments: " + str(cmdlist))
     viirs_sdr_proc = subprocess.Popen(
         cmdlist, cwd=str(work_dir),
         stderr=subprocess.PIPE,

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -24,10 +24,8 @@ and trigger processing on direct readout RDR data (granules or full swaths).
 
 
 import os
-import socket
 import logging
 import multiprocessing
-import netifaces
 import pathlib
 import shutil
 import stat
@@ -38,7 +36,7 @@ import yaml
 from glob import glob
 from datetime import datetime, timedelta
 from multiprocessing.pool import ThreadPool
-from urllib.parse import urlunsplit, urlparse
+from urllib.parse import urlparse
 
 import posttroll.subscriber
 from posttroll.publisher import Publish
@@ -46,10 +44,10 @@ from posttroll.message import Message
 
 import cspp_runner
 import cspp_runner.orbitno
-from cspp_runner import (get_datetime_from_filename, get_sdr_times, is_same_granule)
+from cspp_runner import (get_datetime_from_filename, get_sdr_times)
 from cspp_runner.post_cspp import (get_sdr_files,
                                    create_subdirname,
-                                   pack_sdr_files, make_okay_files,
+                                   pack_sdr_files,
                                    cleanup_cspp_workdir)
 from cspp_runner.pre_cspp import fix_rdrfile
 
@@ -243,7 +241,7 @@ def update_ancillary_files(url_jpss_remote_anc_dir,
         timeout=timeout)
 
 
-def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
+def run_cspp(work_dir, viirs_sdr_call, viirs_sdr_options, viirs_rdr_files):
     """Run CSPP on VIIRS RDR files."""
     LOG.info("viirs_sdr_options = " + str(viirs_sdr_options))
     path = os.environ["PATH"]
@@ -252,11 +250,7 @@ def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
         LOG.warning("No options will be passed to CSPP")
         viirs_sdr_options = []
 
-    cspp_workdir = os.environ.get("CSPP_WORKDIR", '')
-    try:
-        working_dir = tempfile.mkdtemp(dir=cspp_workdir)
-    except OSError:
-        working_dir = tempfile.mkdtemp()
+    os.environ.update({"CSPP_WORKDIR": str(work_dir)})
 
     # Run the command:
     cmdlist = [viirs_sdr_call]
@@ -266,7 +260,7 @@ def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
     t0_wall = time.time()
     LOG.info("Popen call arguments: " + str(cmdlist))
     viirs_sdr_proc = subprocess.Popen(
-        cmdlist, cwd=working_dir,
+        cmdlist, cwd=str(work_dir),
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE)
     while True:
@@ -283,129 +277,26 @@ def run_cspp(viirs_sdr_call, viirs_sdr_options, *viirs_rdr_files):
 
     LOG.info("Seconds process time: " + (str(time.process_time() - t0_clock)))
     LOG.info("Seconds wall clock time: " + (str(time.time() - t0_wall)))
-
     viirs_sdr_proc.poll()
-    return working_dir
 
-
-def publish_sdr(publisher, result_files, mda, site, mode,
-                publish_topic, **kwargs):
-    """Publish the messages that SDR files are ready."""
-    if not result_files:
-        return
-
-    # Now publish:
-    to_send = mda.copy()
-    # Delete the RDR uri and uid from the message:
-    try:
-        del (to_send['uri'])
-    except KeyError:
-        LOG.warning("Couldn't remove URI from message")
-    try:
-        del (to_send['uid'])
-    except KeyError:
-        LOG.warning("Couldn't remove UID from message")
-
-    if 'orbit' in kwargs:
-        to_send["orig_orbit_number"] = to_send["orbit_number"]
-        to_send["orbit_number"] = kwargs['orbit']
-
-    to_send["dataset"] = []
-    start_times = set()
-    end_times = set()
-    for result_file in result_files:
-        filename = os.path.basename(result_file)
-        to_send[
-            'dataset'].append({'uri': urlunsplit(('ssh', socket.gethostname(),
-                                                  result_file, '', '')),
-                               'uid': filename})
-        (start_time, end_time) = get_sdr_times(filename)
-        start_times.add(start_time)
-        end_times.add(end_time)
-    to_send['format'] = 'SDR'
-    to_send['type'] = 'HDF5'
-    to_send['data_processing_level'] = '1B'
-    to_send['start_time'] = min(start_times)
-    to_send['end_time'] = max(end_times)
-
-    LOG.debug('Site = %s', site)
-    LOG.debug('Publish topic = %s', publish_topic)
-    msg = Message('/'.join(('',
-                            publish_topic,
-                            to_send['format'],
-                            to_send['data_processing_level'],
-                            site,
-                            mode,
-                            'polar',
-                            'direct_readout')),
-                  "dataset", to_send).encode()
-    LOG.debug("sending: " + str(msg))
-    publisher.send(msg)
-
-
-def spawn_cspp(current_granule, *glist, viirs_sdr_call, viirs_sdr_options, **kwargs):
-    """Spawn a CSPP run on the set of RDR files given."""
-    start_time = kwargs.get('start_time')
-    platform_name = kwargs.get('platform_name')
-
-    LOG.info("Start CSPP: RDR files = " + str(glist))
-    working_dir = run_cspp(viirs_sdr_call, viirs_sdr_options, *glist)
-    LOG.info("CSPP SDR processing finished...")
-    # Assume everything has gone well!
-    new_result_files = get_sdr_files(working_dir, platform_name=platform_name)
-    LOG.info("SDR file names: %s", str([os.path.basename(f) for f in new_result_files]))
-    if len(new_result_files) == 0:
-        LOG.warning("No SDR files available. CSPP probably failed!")
-        return working_dir, []
-
-    LOG.info("current_granule = " + str(current_granule))
-    LOG.info("glist = " + str(glist))
-    if current_granule in glist and len(glist) == 1:
-        LOG.info("Current granule is identical to the 'list of granules'" +
-                 " No sdr result files will be skipped")
-        return working_dir, new_result_files
-
-    # Only bother about the "current granule" - skip the rest
-    if start_time:
-        LOG.info("Start time of current granule (from messages): %s", start_time.strftime('%Y-%m-%d %H:%M'))
-
-    start_time = get_datetime_from_filename(current_granule)
-    LOG.info("Start time of current granule: %s", start_time.strftime('%Y-%m-%d %H:%M:%S'))
-    sec_tolerance = int(kwargs.get('granule_time_tolerance', 10))
-    LOG.info("Time tolerance to identify which SDR granule belong " +
-             "to the RDR granule being processed: " + str(sec_tolerance))
-    result_files = [new_file for new_file in new_result_files if is_same_granule(
-        current_granule, new_file, sec_tolerance)]
-
-    LOG.info("Number of results files = " + str(len(result_files)))
-    return working_dir, result_files
-
-
-def get_local_ips():
-    """Get the local IP address of where CSPP is running."""
-    inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
-                  for iface in netifaces.interfaces()]
-    ips = []
-    for addr in inet_addrs:
-        if addr is not None:
-            for add in addr:
-                ips.append(add['addr'])
-    return ips
+    return
 
 
 class ViirsSdrProcessor:
     """Container for the VIIRS SDR processing based on CSPP."""
 
-    def __init__(self, ncpus, level1_home):
+    def __init__(self, ncpus, level1_home, publish_topic):
         """Initialize the VIIRS processing class."""
         self.pool = ThreadPool(ncpus)
         self.ncpus = ncpus
+        self.publish_topic = publish_topic
 
-        self.orbit_number = 1  # Initialised orbit number
+        self.orbit_number = 0  # Initialised orbit number
         self.platform_name = 'unknown'  # Ex.: Suomi-NPP
         self.fullswath = False
         self.cspp_results = []
         self.glist = []
+        self.working_dir = None
         self.pass_start_time = None
         self.result_files = []
         self.sdr_home = level1_home
@@ -416,15 +307,14 @@ class ViirsSdrProcessor:
         self.fullswath = False
         self.cspp_results = []
         self.glist = []
+        self.working_dir = None
         self.pass_start_time = None
-        self.result_files = []
+        self.platform_name = 'unknown'
+        self.orbit_number = 0  # Initialised orbit number
+        # self.result_files = []
 
-    def pack_sdr_files(self, subd):
-        """Pack the SDR files together in one directory per pass."""
-        return pack_sdr_files(self.result_files, self.sdr_home, subd)
-
-    def run(self, msg, viirs_sdr_call, viirs_sdr_options,
-            granule_time_tolerance=10):
+    def run(self, msg, publisher, viirs_sdr_call, viirs_sdr_options,
+            granule_time_tolerance=10, granule_specific_working_dir=False):
         """Start the VIIRS SDR processing using CSPP on one rdr granule."""
         if msg:
             LOG.debug("Received message: " + str(msg))
@@ -437,12 +327,12 @@ class ViirsSdrProcessor:
             keeper = self.glist[1]
             LOG.info("Start CSPP: RDR files = " + str(self.glist))
             self.cspp_results.append(
-                self.pool.apply_async(
-                    spawn_cspp,
-                    [keeper] + self.glist,
-                    {"viirs_sdr_call": viirs_sdr_call,
-                     "viirs_sdr_options": viirs_sdr_options,
-                     "granule_time_tolerance": granule_time_tolerance}))
+                self.pool.apply_async(self.spawn_cspp,
+                                      args=(keeper, self.glist, publisher,
+                                            viirs_sdr_call,
+                                            viirs_sdr_options),
+                                      kwds={"granule_time_tolerance":
+                                            granule_time_tolerance}))
             LOG.debug("Inside run: Return with a False...")
             return False
         elif msg and ('platform_name' not in msg.data or 'sensor' not in msg.data):
@@ -460,16 +350,9 @@ class ViirsSdrProcessor:
         LOG.debug("\tMessage:")
         LOG.debug(str(msg))
         urlobj = urlparse(msg.data['uri'])
-        LOG.debug("Server = " + str(urlobj.netloc))
-        url_ip = socket.gethostbyname(urlobj.netloc)
-        if url_ip not in get_local_ips():
-            LOG.warning(
-                "Server %s not the current one: %s" % (str(urlobj.netloc),
-                                                       socket.gethostname()))
-
-        LOG.info("Ok... " + str(urlobj.netloc))
-        LOG.info("Sat and Instrument: " + str(msg.data['platform_name']) +
-                 " " + str(msg.data['sensor']))
+        LOG.info("Sat and Instrument: %s %s",
+                 str(msg.data['platform_name']),
+                 str(msg.data['sensor']))
 
         self.platform_name = str(msg.data['platform_name'])
         self.message_data = msg.data
@@ -494,27 +377,20 @@ class ViirsSdrProcessor:
 
         # Check if the file exists:
         if not os.path.exists(rdr_filename):
-            LOG.error("File is reported to be dispatched " +
-                      "but is not there! File = " +
-                      rdr_filename)
+            LOG.error("File is reported to be dispatched but is not there! File = %s", rdr_filename)
             return True
 
         # Do processing:
-        LOG.info("RDR to SDR processing on npp/viirs with CSPP start!" +
-                 " Start time = " + str(start_time))
-        LOG.info("File = %s" % str(rdr_filename))
+        LOG.info("VIIRS RDR to SDR processing with CSPP start! Start time = %s", str(start_time))
+        LOG.info("File = %s", str(rdr_filename))
         # Fix orbit number in RDR file:
         LOG.info("Fix orbit number in rdr file...")
         try:
             rdr_filename, orbnum = fix_rdrfile(rdr_filename)
         except IOError:
-            LOG.exception(
-                'Failed to fix orbit number in RDR file = ' +
-                str(urlobj.path))
+            LOG.exception('Failed to fix orbit number in RDR file = %s', str(urlobj.path))
         except cspp_runner.orbitno.NoTleFile:
-            LOG.exception(
-                'Failed to fix orbit number in RDR file = ' +
-                str(urlobj.path))
+            LOG.exception('Failed to fix orbit number in RDR file = %s', str(urlobj.path))
             LOG.error('No TLE file...')
         if orbnum:
             self.orbit_number = orbnum
@@ -548,27 +424,144 @@ class ViirsSdrProcessor:
                          " Continue")
                 return True
 
+        working_subdir_name = None
         start_time = get_datetime_from_filename(keeper)
         if self.pass_start_time is None:
             self.pass_start_time = start_time
-            LOG.debug("Set the start time of the entire swath: %s", self.pass_start_time.strftime('%Y-%m-%d %H:%M:%S'))
+            LOG.debug("Set the start time of the entire swath: %s",
+                      self.pass_start_time.strftime('%Y-%m-%d %H:%M:%S'))
+            # Create the name of the pass unique sub-directory (which will also
+            # be the working dir) if not already done:
+            working_subdir_name = create_subdirname(self.pass_start_time,
+                                                    platform_name=self.platform_name,
+                                                    orbit=self.orbit_number)
         else:
             LOG.debug("Start time of the entire swath is not changed")
+
+        # Get the default CSPP Working dir:
+        cspp_workdir = os.environ.get("CSPP_WORKDIR", '')
+
+        # Create the working directory if it doesn't exist already:
+        if not self.working_dir:
+            self.working_dir = pathlib.Path(self.sdr_home) / working_subdir_name
+            try:
+                self.working_dir.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                self.working_dir = pathlib.Path(tempfile.mkdtemp(dir=cspp_workdir))
+                LOG.warning("Failed creating the requested working directory path. created this instead: %s",
+                            self.working_dir)
 
         LOG.info("Before call to spawn_cspp. Argument list = " +
                  str([keeper] + self.glist))
         LOG.info("Start time: %s", start_time.strftime('%Y-%m-%d %H:%M:%S'))
         self.cspp_results.append(
-            self.pool.apply_async(
-                spawn_cspp,
-                [keeper] + self.glist,
-                {"viirs_sdr_call": viirs_sdr_call,
-                 "viirs_sdr_options": viirs_sdr_options}))
+            self.pool.apply_async(self.spawn_cspp,
+                                  args=(keeper, self.glist, publisher,
+                                        viirs_sdr_call,
+                                        viirs_sdr_options),
+                                  kwds={"granule_time_tolerance": granule_time_tolerance}))
+
         if self.fullswath:
             LOG.info("Full swath. Break granules loop")
             return False
 
         return True
+
+    def spawn_cspp(self, current_granule, glist, publisher,
+                   viirs_sdr_call, viirs_sdr_options, **kwargs):
+        """Spawn a CSPP run on the set of RDR files given."""
+        LOG.info("current_granule = " + str(current_granule))
+        LOG.info("glist = " + str(glist))
+        if current_granule in glist and len(glist) == 1:
+            LOG.info("Current granule is identical to the 'list of granules'" +
+                     " No sdr result files will be skipped")
+
+        start_time = get_datetime_from_filename(current_granule)
+        LOG.info("Start time of current granule: %s", start_time.strftime('%Y-%m-%d %H:%M:%S'))
+        sec_tolerance = int(kwargs.get('granule_time_tolerance', 10))
+        LOG.info("Time tolerance to identify which SDR granule belong " +
+                 "to the RDR granule being processed: " + str(sec_tolerance))
+
+        working_dir = pathlib.Path(tempfile.mkdtemp(dir=self.working_dir))
+
+        LOG.info("Start CSPP: RDR files = " + str(glist))
+        LOG.info("Run from working dir = %s", working_dir)
+        run_cspp(working_dir, viirs_sdr_call, viirs_sdr_options, *glist)
+        LOG.info("CSPP SDR processing finished...")
+        # Assume everything has gone well!
+        new_result_files = get_sdr_files(working_dir,
+                                         platform_name=self.platform_name,
+                                         start_time=start_time,
+                                         time_tolerance=timedelta(seconds=sec_tolerance))
+        if len(new_result_files) == 0:
+            LOG.warning("No SDR files available. CSPP probably failed!")
+            return []
+
+        LOG.info("Move the sdr files to the final destination: %s", self.working_dir)
+        new_result_files = pack_sdr_files(new_result_files, self.working_dir)
+
+        LOG.info("SDR file names: %s", str([os.path.basename(f) for f in new_result_files]))
+        LOG.info("Number of SDR results files = " + str(len(new_result_files)))
+        # Now start publish the files:
+        self.publish_sdr(publisher, new_result_files)
+
+        # Cleanup the working dir:
+        if working_dir != self.working_dir:
+            LOG.info("Clean the working directory: %s", str(working_dir))
+            cleanup_cspp_workdir(working_dir)
+
+        LOG.debug("Return all SDR result files.")
+        return new_result_files
+
+    def publish_sdr(self, publisher, result_files):
+        """Publish the messages that SDR files are ready."""
+        if not result_files:
+            return
+
+        # Now publish:
+        to_send = self.message_data.copy()
+        # Delete the RDR uri and uid from the message:
+        try:
+            del (to_send['uri'])
+        except KeyError:
+            LOG.warning("Couldn't remove URI from message")
+        try:
+            del (to_send['uid'])
+        except KeyError:
+            LOG.warning("Couldn't remove UID from message")
+
+        if self.orbit_number > 0:
+            to_send["orig_orbit_number"] = to_send["orbit_number"]
+            to_send["orbit_number"] = self.orbit_number
+
+        to_send["dataset"] = []
+        start_times = set()
+        end_times = set()
+
+        for result_file in result_files:
+            filename = os.path.basename(result_file)
+            to_send['dataset'].append({'uri': str(result_file), 'uid': filename})
+            (start_time, end_time) = get_sdr_times(filename)
+            start_times.add(start_time)
+            end_times.add(end_time)
+
+        to_send['format'] = 'SDR'
+        to_send['type'] = 'HDF5'
+        to_send['data_processing_level'] = '1B'
+        to_send['start_time'] = min(start_times)
+        to_send['end_time'] = max(end_times)
+
+        LOG.debug('Publish topic = %s', self.publish_topic)
+        msg = Message('/'.join(('',
+                                self.publish_topic,
+                                to_send['format'],
+                                to_send['data_processing_level'],
+                                'polar',
+                               'direct_readout')),
+                      "dataset", to_send).encode()
+        LOG.debug("sending: " + str(msg))
+        publisher.send(msg)
+        LOG.debug("After having published/sent message.")
 
 
 def npp_rolling_runner(
@@ -582,8 +575,6 @@ def npp_rolling_runner(
         anc_update_stampfile_prefix,
         mirror_jpss_ancillary,
         subscribe_topics,
-        site,
-        mode,
         publish_topic,
         level1_home,
         viirs_sdr_call,
@@ -638,46 +629,36 @@ def npp_rolling_runner(
                                         subscribe_topics, True) as subscr:
         with Publish(**pubconf) as publisher:
             while True:
+                LOG.debug("Re-initialise the viirs processor instance.")
                 viirs_proc.initialise()
                 for msg in subscr.recv(timeout=300):
                     status = viirs_proc.run(
-                        msg, viirs_sdr_call, viirs_sdr_options,
+                        msg, publisher,
+                        viirs_sdr_call, viirs_sdr_options,
                         granule_time_tolerance)
                     LOG.debug("Sent message to run: %s", str(msg))
-                    LOG.debug("Status: %s", str(status))
+                    LOG.debug("Running: %s", str(status))
                     if not status:
                         break  # end the loop and reinitialize !
 
-                LOG.debug(
-                    "Received message data = %s", str(viirs_proc.message_data))
-                proc_start_time = datetime.utcnow()
-                tobj = viirs_proc.pass_start_time
-                LOG.info("Time used in sub-dir name: " +
-                         str(tobj.strftime("%Y-%m-%d %H:%M")))
-                subd = create_subdirname(tobj, platform_name=viirs_proc.platform_name,
-                                         orbit=viirs_proc.orbit_number)
-                LOG.info("Create sub-directory for sdr files: %s" % str(subd))
+                if viirs_proc.pass_start_time:
+                    LOG.info("Seconds since granule start: {:.1f}".format(
+                        (datetime.utcnow() - viirs_proc.pass_start_time).total_seconds()))
+                else:
+                    LOG.debug("No start time for overpass set.")
+                    continue
 
-                LOG.info("Get the results from the multiprocessing pool-run")
+                LOG.info("No new rdr granules coming in anymore...")
+                LOG.debug("Get the results from the multiprocessing pool-run")
                 for res in viirs_proc.cspp_results:
-                    working_dir, tmp_result_files = res.get()
-                    viirs_proc.result_files = tmp_result_files
-                    sdr_files = viirs_proc.pack_sdr_files(subd)
-                    LOG.info("Cleaning up directory %s" % working_dir)
-                    cleanup_cspp_workdir(working_dir)
-                    publish_sdr(publisher, sdr_files,
-                                viirs_proc.message_data,
-                                site, mode, publish_topic,
-                                orbit=viirs_proc.orbit_number)
+                    result_files = res.get()
+                    if len(result_files) > 0:
+                        LOG.debug("Results on a granule ready. Number of files = %d. First file = %s",
+                                  len(result_files), result_files[0])
+                    else:
+                        LOG.error("Results on a granule ready, but no SDR files!")
 
-                make_okay_files(viirs_proc.sdr_home, subd)
-
-                LOG.info("Seconds to process SDR: {:.1f}".format(
-                    (datetime.utcnow() - proc_start_time).total_seconds()))
-                LOG.info("Seconds since granule start: {:.1f}".format(
-                    (datetime.utcnow() - tobj).total_seconds()))
-                LOG.info("Now that SDR processing has completed, " +
-                         "check for new LUT files...")
+                LOG.info("Now that SDR processing has completed, check for new LUT files...")
                 fresh = check_lut_files(
                     thr_lut_files_age_days, url_download_trial_frequency_hours,
                     lut_update_stampfile_prefix, lut_dir)

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -256,7 +256,8 @@ def run_cspp(work_dir, viirs_sdr_call, viirs_sdr_options, viirs_rdr_files):
     # Run the command:
     cmdlist = [viirs_sdr_call]
     cmdlist.extend(viirs_sdr_options)
-    cmdlist.extend(viirs_rdr_files)
+    list_of_filepaths = [str(rdr) for rdr in [viirs_rdr_files]]
+    cmdlist.extend(list_of_filepaths)
     t0_clock = time.process_time()
     t0_wall = time.time()
     LOG.info("Popen call arguments: " + str(cmdlist))

--- a/cspp_runner/runner.py
+++ b/cspp_runner/runner.py
@@ -35,7 +35,7 @@ import time
 import yaml
 from glob import glob
 from datetime import datetime, timedelta
-from multiprocessing.pool import ThreadPool
+from multiprocessing.pool import Pool
 from urllib.parse import urlparse
 
 import posttroll.subscriber
@@ -291,7 +291,8 @@ class ViirsSdrProcessor:
 
     def __init__(self, ncpus, level1_home, publish_topic):
         """Initialize the VIIRS processing class."""
-        self.pool = ThreadPool(ncpus)
+        # self.pool = ThreadPool(ncpus)
+        self.pool = Pool(ncpus)
         self.ncpus = ncpus
         self.publish_topic = publish_topic
 

--- a/cspp_runner/tests/conftest.py
+++ b/cspp_runner/tests/conftest.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023 Adam.Dybbroe
+
+# Author(s):
+
+#   Adam.Dybbroe <a000680@c21856.ad.smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Fixtures for unittests."""
+
+
+import pytest
+import datetime
+
+
+def generate_cspp_sdr_granule_filename(prefix, satname, orbit_number, starttime):
+    """Generate a filename that follows the NOAA CSPP SDR file name convention."""
+    now = datetime.datetime.now()
+    granule_length_sec = 84.2
+    endtime = starttime + datetime.timedelta(seconds=granule_length_sec)
+    msec_start = starttime.strftime('%f')[0:1]
+    msec_end = endtime.strftime('%f')[0:1]
+
+    return f'{prefix}_{satname}_d{starttime:%Y%m%d_t%H%M%S}{msec_start}_e{endtime:%H%M%S}{msec_end}_b{orbit_number}_c{now:%Y%m%d%H%M%S%f}_cspp_dev.h5'  # noqa
+
+
+@pytest.fixture
+def fake_empty_viirs_sdr_files(tmp_path):
+    """Write fake empty viirs sdr files."""
+    starttime = datetime.datetime(2023, 5, 10, 14, 30, 53, 800000)
+    return create_full_sdr_list_from_time(tmp_path, starttime)
+
+
+# @pytest.fixture
+# def fake_empty_viirs_sdr_files_nine_seconds_deviation(tmp_path):
+#     """Write fake empty viirs sdr files."""
+#     starttime = datetime.datetime(2023, 5, 10, 14, 30, 53, 800000) + datetime.timedelta(seconds=9)
+#     return create_full_sdr_list_from_time(tmp_path, starttime)
+
+
+def create_full_sdr_list_from_time(sdr_dir, starttime):
+    """Create a full list of SDR files."""
+    satname = 'npp'
+    orbit = '59761'
+    filelist = []
+    for prefix in ['GDNBO', 'GIMGO', 'GITCO', 'GMODO', 'GMTCO', 'IVCDB', 'SVDNB']:
+        file_path = sdr_dir / generate_cspp_sdr_granule_filename(prefix, satname, orbit, starttime)
+        file_path.touch()
+        filelist.append(file_path)
+
+    for mband in range(1, 17):
+        prefix = f'SVM{mband:02d}'
+        file_path = sdr_dir / generate_cspp_sdr_granule_filename(prefix, satname, orbit, starttime)
+        file_path.touch()
+        filelist.append(file_path)
+
+    for iband in range(1, 6):
+        prefix = f'SVI{iband:02d}'
+        file_path = sdr_dir / generate_cspp_sdr_granule_filename(prefix, satname, orbit, starttime)
+        file_path.touch()
+        filelist.append(file_path)
+
+    return filelist

--- a/cspp_runner/tests/test_post_cspp.py
+++ b/cspp_runner/tests/test_post_cspp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 pytroll-cspp-runner developers
+# Copyright (c) 2021, 2023 pytroll-cspp-runner developers
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,10 +16,10 @@
 """Tests for post-cspp module."""
 
 import logging
-import os
 
 
 def test_pack_sdr_files(tmp_path, caplog):
+    """Test 'packing' (copy the relevant granules to the destination directory) the SDR files."""
     from cspp_runner.post_cspp import pack_sdr_files
 
     # create dummy source file
@@ -29,11 +29,9 @@ def test_pack_sdr_files(tmp_path, caplog):
     dest = tmp_path / "path" / "to" / "sdr_dir"
 
     with caplog.at_level(logging.DEBUG):
-        newnames = pack_sdr_files(
-            [p],
-            os.fspath(dest),
-            "subdir")
+        newnames = pack_sdr_files([p], dest)
+
     assert "Number of SDR files: 1" in caplog.text
-    assert (dest / "subdir" / "sdr.h5").exists()
+    assert (dest / "sdr.h5").exists()
     assert len(newnames) == 1
     assert isinstance(newnames[0], str)

--- a/cspp_runner/tests/test_runner.py
+++ b/cspp_runner/tests/test_runner.py
@@ -251,8 +251,8 @@ def test_check_lut_files_outofdate(tmp_path, caplog):
     assert not res
 
 
-def test_run_cspp(monkeypatch, tmp_path):
-    """Test running CSPP."""
+def test_run_cspp_one_rdr(monkeypatch, tmp_path):
+    """Test running CSPP on one RDR file."""
     import cspp_runner.runner
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
 
@@ -262,6 +262,22 @@ def test_run_cspp(monkeypatch, tmp_path):
     fake_rdr_file.touch()
 
     cspp_runner.runner.run_cspp(working_dir, "true", [], fake_rdr_file)
+
+
+def test_run_cspp_list_of_rdr_granules(monkeypatch, tmp_path):
+    """Test running CSPP on a list of rdr files (granules)."""
+    import cspp_runner.runner
+    monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
+
+    working_dir = tmp_path / "env"
+    working_dir.mkdir(parents=True)
+    fake_rdr_granule1 = tmp_path / "RNSCA-RVIRS_npp_d20230618_t1217289_e1218543_b00001_c20230618121900480000_drlu_ops.h5"  # noqa
+    fake_rdr_granule1.touch()
+    fake_rdr_granule2 = tmp_path / "RNSCA-RVIRS_npp_d20230618_t1218543_e1220196_b00001_c20230618122016129000_drlu_ops.h5"  # noqa
+    fake_rdr_granule2.touch()
+
+    fake_rdr_files = [fake_rdr_granule1, fake_rdr_granule2]
+    cspp_runner.runner.run_cspp(working_dir, "true", [], fake_rdr_files)
 
 
 @patch('posttroll.message.Message')
@@ -434,8 +450,8 @@ def test_rolling_runner(tmp_path, caplog, monkeypatch, fakemessage,
                 "gopher://example.org/luts",
                 os.fspath(tmp_path / "stamp_lut"),
                 "true")
+
     assert "Dynamic ancillary data will be updated" in caplog.text
-    assert "Received message data" in caplog.text
+    assert "Received message:" in caplog.text
     assert "Now that SDR processing has completed" in caplog.text
-    assert "Seconds to process SDR: " in caplog.text
     assert "Seconds since granule start: " in caplog.text

--- a/cspp_runner/tests/test_runner.py
+++ b/cspp_runner/tests/test_runner.py
@@ -251,7 +251,7 @@ def test_check_lut_files_outofdate(tmp_path, caplog):
     assert not res
 
 
-def test_run_cspp_one_rdr(monkeypatch, tmp_path):
+def test_run_cspp_one_rdr(monkeypatch, tmp_path, caplog):
     """Test running CSPP on one RDR file."""
     import cspp_runner.runner
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
@@ -261,10 +261,15 @@ def test_run_cspp_one_rdr(monkeypatch, tmp_path):
     fake_rdr_file = tmp_path / "RNSCA-RVIRS_j02_d20230511_t0016580_e0018234_b02578_c20230511001837310000_drlu_ops.h5"
     fake_rdr_file.touch()
 
-    cspp_runner.runner.run_cspp(working_dir, "true", [], fake_rdr_file)
+    with caplog.at_level(logging.DEBUG):
+        cspp_runner.runner.run_cspp(working_dir, "true", [], [fake_rdr_file])
+
+    assert "Run CSPP on 1 RDR file(s):" in caplog.text
+    assert "Popen call arguments: ['true', " in caplog.text
+    assert "RNSCA-RVIRS_j02_d20230511_t0016580_e0018234_b02578_c20230511001837310000_drlu_ops.h5" in caplog.text
 
 
-def test_run_cspp_list_of_rdr_granules(monkeypatch, tmp_path):
+def test_run_cspp_list_of_rdr_granules(monkeypatch, tmp_path, caplog):
     """Test running CSPP on a list of rdr files (granules)."""
     import cspp_runner.runner
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
@@ -277,7 +282,13 @@ def test_run_cspp_list_of_rdr_granules(monkeypatch, tmp_path):
     fake_rdr_granule2.touch()
 
     fake_rdr_files = [fake_rdr_granule1, fake_rdr_granule2]
-    cspp_runner.runner.run_cspp(working_dir, "true", [], fake_rdr_files)
+    with caplog.at_level(logging.DEBUG):
+        cspp_runner.runner.run_cspp(working_dir, "true", [], fake_rdr_files)
+
+    assert "Run CSPP on 2 RDR file(s):" in caplog.text
+    assert "Popen call arguments: ['true', " in caplog.text
+    assert "RNSCA-RVIRS_npp_d20230618_t1217289_e1218543_b00001_c20230618121900480000_drlu_ops.h5" in caplog.text
+    assert "RNSCA-RVIRS_npp_d20230618_t1218543_e1220196_b00001_c20230618122016129000_drlu_ops.h5" in caplog.text
 
 
 @patch('posttroll.message.Message')

--- a/cspp_runner/tests/test_runner.py
+++ b/cspp_runner/tests/test_runner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 pytroll-cspp-runner developers
+# Copyright (c) 2021, 2023 pytroll-cspp-runner developers
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,10 +19,22 @@ import datetime
 import logging
 import os
 import signal
-import unittest.mock
-
+from unittest.mock import patch
+import pathlib
 import posttroll.message
 import pytest
+
+
+class FakePublisher:
+    """Fake Publisher class."""
+
+    def __init__(self):
+        """Initialize the Fake Publisher class."""
+        self.messages = []
+
+    def send(self, msg):
+        """Fake sending a message."""
+        self.messages.append(msg)
 
 
 @pytest.fixture
@@ -37,21 +49,23 @@ def fakefile(tmp_path):
 
 @pytest.fixture
 def fakemessage(fakefile):
+    """Fake an incoming message with an RDR file for CSPP."""
     return posttroll.message.Message(
-            rawstr="pytroll://file/snpp/viirs/direktempfang file "
-            "pytroll@oflks333.dwd.de 2021-12-20T15:01:02.780614 v1.01 "
-            'application/json {"path": "", "start_time": '
-            '"2021-12-17T09:59:00.300000", "end_time": '
-            '"2021-12-17T10:11:48.400000", "orbit_number": 1, "processing_time": '
-            '"2021-12-17T10:12:06.466000", "uri": '
-            f'"{fakefile!s}", "uid": '
-            '"RNSCA-RVIRS_npp_d20211217_t0959003_e1011484_b00001_'
-            'c20211217101206466000_all-_dev.h5", "sensor": ["viirs"], '
-            '"platform_name": "Suomi-NPP"}')
+        rawstr="pytroll://file/snpp/viirs/direktempfang file "
+        "pytroll@oflks333.dwd.de 2021-12-20T15:01:02.780614 v1.01 "
+        'application/json {"path": "", "start_time": '
+        '"2021-12-17T09:59:00.300000", "end_time": '
+        '"2021-12-17T10:11:48.400000", "orbit_number": 1, "processing_time": '
+        '"2021-12-17T10:12:06.466000", "uri": '
+        f'"{fakefile!s}", "uid": '
+        '"RNSCA-RVIRS_npp_d20211217_t0959003_e1011484_b00001_'
+        'c20211217101206466000_all-_dev.h5", "sensor": ["viirs"], '
+        '"platform_name": "Suomi-NPP"}')
 
 
 @pytest.fixture
 def fake_result_names(tmp_path):
+    """Make a full list of CSPP SDR filenames."""
     p = tmp_path / "results"
     all = []
     for lbl in ["GMTCO", "SVM02", "SVM09", "SVM10", "SVM12"]:
@@ -72,6 +86,7 @@ def fake_result_names(tmp_path):
 
 @pytest.fixture
 def fake_results(tmp_path, fake_result_names):
+    """Fake a CSPP result of SDR files."""
     p = tmp_path / "results"
     p.mkdir(parents=True, exist_ok=True)
     created = []
@@ -86,48 +101,44 @@ def test_run_fullswath(tmp_path, fakefile, fakemessage, caplog):
     """Test the runner with a single fullswath file."""
     from cspp_runner.runner import ViirsSdrProcessor
 
-    with unittest.mock.patch("cspp_runner.runner.ThreadPool") as crT, \
-         unittest.mock.patch("cspp_runner.runner.fix_rdrfile") as csr:
+    fake_publisher = FakePublisher()
+
+    with patch("cspp_runner.runner.ThreadPool") as crT, \
+            patch("cspp_runner.runner.fix_rdrfile") as csr:
         csr.return_value = (os.fspath(fakefile), 42)
-        vsp = ViirsSdrProcessor(1, tmp_path / "outdir")
+        vsp = ViirsSdrProcessor(1, tmp_path / "outdir", 'fake_topic')
+
         with caplog.at_level(logging.ERROR):
-            vsp.run(fakemessage, "true", [])
+            vsp.run(fakemessage, fake_publisher, "true", [])
         assert crT().apply_async.call_count == 1
         assert caplog.text == ""
 
 
-def test_publish(fake_results):
+def test_publish(tmp_path, fake_results, fakemessage, fake_empty_viirs_sdr_files):
     """Test publishing SDR."""
-    from cspp_runner.runner import publish_sdr
-
-    class FakePublisher:
-        def __init__(self):
-            self.messages = []
-
-        def send(self, msg):
-            self.messages.append(msg)
+    from cspp_runner.runner import ViirsSdrProcessor
 
     fake_publisher = FakePublisher()
 
-    publish_sdr(
-            fake_publisher,
-            fake_results,
-            {"orbit_number": 21200},
-            "wonderland",
-            "test",
-            "treasure/collected/complete",
-            orbit=42)
+    with patch("cspp_runner.runner.ThreadPool"), \
+            patch("cspp_runner.post_cspp.get_sdr_files") as get_sdr_files:
+        vsp = ViirsSdrProcessor(1, tmp_path / "outdir", 'fake_topic')
+        get_sdr_files.return_value = fake_empty_viirs_sdr_files
+        vsp.orbit_number = 42
+        vsp.message_data = fakemessage.data
+
+        vsp.publish_sdr(fake_publisher, fake_results)
+
     assert len(fake_publisher.messages) == 1
     msg = fake_publisher.messages[0]
-    assert msg.startswith(
-            "pytroll://treasure/collected/complete/SDR/1B/wonderland"
-            "/test/polar/direct_readout dataset")
+
+    assert msg.startswith("pytroll://fake_topic/SDR/1B/polar/direct_readout")
     assert '"end_time": "2021-12-29T13:55:39.700000"' in msg
     assert '"start_time": "2021-12-29T13:42:52.700000"' in msg
 
 
 @pytest.mark.parametrize(
-        "funcname", ["update_lut_files", "update_ancillary_files"])
+    "funcname", ["update_lut_files", "update_ancillary_files"])
 def test_update_missing_env(monkeypatch, tmp_path, funcname):
     """Test updating fails when env missing."""
     monkeypatch.delenv("CSPP_WORKDIR", raising=False)
@@ -136,14 +147,14 @@ def test_update_missing_env(monkeypatch, tmp_path, funcname):
     # should raise exception when no workdir set
     with pytest.raises(EnvironmentError):
         updater(
-                "gopher://dummy/location",
-                os.fspath(tmp_path / "stampfile"),
-                "true")
+            "gopher://dummy/location",
+            os.fspath(tmp_path / "stampfile"),
+            "true")
 
 
 @pytest.mark.parametrize(
-        "funcname,label", [("update_lut_files", "LUT"),
-                           ("update_ancillary_files", "ANC")])
+    "funcname,label", [("update_lut_files", "LUT"),
+                       ("update_ancillary_files", "ANC")])
 def test_update_nominal(monkeypatch, tmp_path, caplog, funcname, label):
     """Test update nominal case."""
     import cspp_runner.runner
@@ -155,7 +166,7 @@ def test_update_nominal(monkeypatch, tmp_path, caplog, funcname, label):
                 "echo")
     assert f"Download command for {label:s}" in caplog.text
     assert caplog.text.split("\n")[2].endswith(
-            f"-W {tmp_path / 'env'!s}")
+        f"-W {tmp_path / 'env'!s}")
     assert "downloaded" in caplog.text
     # I tried to use the technique at
     # https://stackoverflow.com/a/20503374/974555 to patch datetime.now, but
@@ -170,19 +181,20 @@ def test_update_nominal(monkeypatch, tmp_path, caplog, funcname, label):
 
 
 @pytest.mark.parametrize(
-        "funcname", ["update_lut_files", "update_ancillary_files"])
+    "funcname", ["update_lut_files", "update_ancillary_files"])
 def test_update_error(monkeypatch, tmp_path, caplog, funcname):
     """Check that a failed LUT update is logged to stderr.
 
-    And that the stampfile is NOT updated in this case."""
+    And that the stampfile is NOT updated in this case.
+    """
     import cspp_runner.runner
     updater = getattr(cspp_runner.runner, funcname)
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
     with caplog.at_level(logging.ERROR):
         updater(
-                "gother://dummy/location",
-                os.fspath(tmp_path / "stampfile"),
-                "false")
+            "gother://dummy/location",
+            os.fspath(tmp_path / "stampfile"),
+            "false")
     assert "exit code 1" in caplog.text
     now = datetime.datetime.utcnow()
     justnow = now - datetime.timedelta(seconds=5)
@@ -198,7 +210,7 @@ def test_check_lut_files_virgin(tmp_path):
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()
     res = cspp_runner.runner.check_lut_files(
-            5, 1, "prefix", os.fspath(empty_dir))
+        5, 1, "prefix", os.fspath(empty_dir))
     assert not res
 
 
@@ -214,7 +226,7 @@ def test_check_lut_files_uptodate(tmp_path):
         fn = stamp.with_suffix(f".{dt:%Y%m%d%H%M}")
         fn.touch()
     res = cspp_runner.runner.check_lut_files(
-            5, 1, os.fspath(stamp), "irrelevant")
+        5, 1, os.fspath(stamp), "irrelevant")
     assert res
 
 
@@ -233,9 +245,9 @@ def test_check_lut_files_outofdate(tmp_path, caplog):
     lutfile.touch()
     os.utime(lutfile, (yesteryear.timestamp(),)*2)
     res = cspp_runner.runner.check_lut_files(
-            5, 1,
-            os.fspath(stamp),
-            os.fspath(lut_dir))
+        5, 1,
+        os.fspath(stamp),
+        os.fspath(lut_dir))
     assert not res
 
 
@@ -243,49 +255,102 @@ def test_run_cspp(monkeypatch, tmp_path):
     """Test running CSPP."""
     import cspp_runner.runner
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
-    (tmp_path / "env").mkdir(parents=True)
-    cspp_runner.runner.run_cspp("true", [])
+
+    working_dir = tmp_path / "env"
+    working_dir.mkdir(parents=True)
+    fake_rdr_file = tmp_path / "RNSCA-RVIRS_j02_d20230511_t0016580_e0018234_b02578_c20230511001837310000_drlu_ops.h5"
+    fake_rdr_file.touch()
+
+    cspp_runner.runner.run_cspp(working_dir, "true", [], fake_rdr_file)
 
 
-def test_spawn_cspp_nominal(tmp_path, caplog, fake_result_names, monkeypatch):
+@patch('posttroll.message.Message')
+@patch('cspp_runner.runner.create_tmp_workdir')
+def test_spawn_cspp_nominal(create_tmp_workdir, message, tmp_path, caplog,
+                            fakemessage, fake_empty_viirs_sdr_files, monkeypatch):
     """Test spawning CSPP successfully."""
-    import cspp_runner.runner
+    from cspp_runner.runner import ViirsSdrProcessor
+
+    message.return_value = 'my fake dummy message'
+    fake_publisher = FakePublisher()
+
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
     (tmp_path / "env").mkdir(parents=True)
 
-    def fake_run_cspp(call, args, *rdrs):
-        p = tmp_path / "working_dir"
-        p.mkdir()
-        for f in fake_result_names:
-            (p / f.name).touch()
-        return os.fspath(p)
-    with unittest.mock.patch("cspp_runner.runner.run_cspp") as crr:
-        crr.side_effect = fake_run_cspp
-        with caplog.at_level(logging.DEBUG):
-            (wd, rf) = cspp_runner.runner.spawn_cspp(
-                os.fspath(
-                    tmp_path /
-                    "RNSCA-RVIRS_j01_d20211229_t1342527_e1355397_b21199_c20211229144433345000_all-_dev.h5"),
-                viirs_sdr_call="touch",
-                viirs_sdr_options=[],
-                granule_time_tolerance=10)
+    create_tmp_workdir.return_value = tmp_path / "working_dir"
+
+    def fake_run_cspp(workdir, call, args, *rdrs):
+        workdir.mkdir()
+        for f in fake_empty_viirs_sdr_files:
+            (workdir / f.name).touch()
+            os.remove(f)
+        return
+
+    with patch("cspp_runner.runner.ThreadPool"), \
+            patch("cspp_runner.post_cspp.get_sdr_files") as get_sdr_files:
+        vsp = ViirsSdrProcessor(1, tmp_path / "outdir", 'fake_topic')
+        vsp.message_data = fakemessage.data
+
+        get_sdr_files.return_value = fake_empty_viirs_sdr_files
+
+        with patch("cspp_runner.runner.run_cspp") as crr:
+            crr.side_effect = fake_run_cspp
+            vsp.working_dir = fake_empty_viirs_sdr_files[0].parent
+            with caplog.at_level(logging.DEBUG):
+                res_files = vsp.spawn_cspp(
+                    pathlib.Path(os.fspath(
+                        tmp_path /
+                        "RNSCA-RVIRS_npp_d20230510_t1430538_e1432180_b59761_c20230512143418235765_drlu_ops.h5")),
+                    [pathlib.Path(os.fspath(
+                        tmp_path /
+                        "RNSCA-RVIRS_npp_d20230510_t1430538_e1432180_b59761_c20230512143418235765_drlu_ops.h5"))] +
+                    [os.fspath(tmp_path / f"file{i:d})")
+                     for i in range(3)],
+                    # "RNSCA-RVIRS_j01_d20211229_t1342527_e1355397_b21199_c20211229144433345000_all-_dev.h5"),
+                    # fake_workingdir,
+                    publisher=fake_publisher,
+                    viirs_sdr_call="touch",
+                    viirs_sdr_options=[],
+                    granule_time_tolerance=10)
+
     assert "Start CSPP" in caplog.text
     assert "CSPP probably failed" not in caplog.text
-    assert "Number of results files" in caplog.text
-    assert len(rf) == 5
+    assert "CSPP SDR processing finished..." in caplog.text
+    assert "Number of SDR results files" in caplog.text
+    assert len(res_files) == 28
 
 
-def test_spawn_cspp_failure(monkeypatch, tmp_path, caplog):
+def test_spawn_cspp_failure(monkeypatch, fakemessage, tmp_path, caplog):
     """Test spawning CSPP unsuccessfully."""
-    import cspp_runner.runner
+    from cspp_runner.runner import ViirsSdrProcessor
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(tmp_path / "env"))
     (tmp_path / "env").mkdir(parents=True)
-    with caplog.at_level(logging.WARNING):
-        (wd, rf) = cspp_runner.runner.spawn_cspp(
-            *[os.fspath(tmp_path / f"file{i:d})")
-                for i in range(4)],
-            viirs_sdr_call="false",
-            viirs_sdr_options=[])
+
+    fake_publisher = FakePublisher()
+
+    with patch("cspp_runner.runner.ThreadPool"):
+        vsp = ViirsSdrProcessor(1, tmp_path / "outdir", 'fake_topic')
+        vsp.message_data = fakemessage.data
+
+        fake_rdr_file = tmp_path / "RNSCA-RVIRS_j02_d20230511_t0016580_e0018234_b02578_c20230511001837310000_drlu_ops.h5"  # noqa
+        fake_rdr_file.touch()
+        fake_working_dir = tmp_path / 'work_dir'
+        fake_working_dir.mkdir()
+        vsp.working_dir = fake_working_dir
+
+        with caplog.at_level(logging.WARNING):
+            rf = vsp.spawn_cspp(fake_rdr_file,
+                                [pathlib.Path(os.fspath(
+                                    tmp_path /
+                                    "RNSCA-RVIRS_npp_d20230510_t1430538_e1432180_b59761_c20230512143418235765_drlu_ops.h5"))] +  # noqa
+                                [os.fspath(tmp_path / f"file{i:d})")
+                                 for i in range(3)],
+                                publisher=fake_publisher,
+                                viirs_sdr_call="false",
+                                viirs_sdr_options=[],
+                                granule_time_tolerance=10
+                                )
+
     assert len(rf) == 0
     assert "CSPP probably failed!" in caplog.text
 
@@ -310,22 +375,19 @@ def test_rolling_runner(tmp_path, caplog, monkeypatch, fakemessage,
 
     fake_workdir = tmp_path / "workdir"
 
-    def fake_spawn_cspp(current_granule, *glist, viirs_sdr_call,
-                        viirs_sdr_options):
-        fake_workdir.mkdir(exist_ok=True, parents=True)
-
-        return (os.fspath(fake_workdir), fake_results)
     yaml_conf = tmp_path / "publisher.yaml"
     with yaml_conf.open(mode="wt", encoding="ascii") as fp:
         fp.write(fake_publisher_config_contents)
 
     monkeypatch.setenv("CSPP_WORKDIR", os.fspath(fake_workdir))
-    with unittest.mock.patch("posttroll.subscriber.Subscribe") as psS, \
-         unittest.mock.patch("cspp_runner.runner.Publish"), \
-         unittest.mock.patch("cspp_runner.runner.spawn_cspp", new=fake_spawn_cspp) as crs, \
-         caplog.at_level(logging.DEBUG):
+    with patch("posttroll.subscriber.Subscribe") as psS, \
+            patch("cspp_runner.runner.Publish"), \
+            patch("cspp_runner.runner.ViirsSdrProcessor.spawn_cspp") as spawn_cspp, \
+            caplog.at_level(logging.DEBUG):
+
         psS.return_value.__enter__.return_value.recv.return_value = [fakemessage]
-        crs.return_value = (os.fspath(fake_workdir), fake_results)
+        spawn_cspp.return_value = fake_results
+
         try:
             signal.signal(signal.SIGALRM, handler)
             signal.alarm(2)
@@ -335,21 +397,22 @@ def test_rolling_runner(tmp_path, caplog, monkeypatch, fakemessage,
                                "gopher://example.org/luts", "true",
                                "gopher://example.org/ancs",
                                os.fspath(tmp_path / "stamp_anc"),
-                               "true", "/file/available/rdr", "earth",
-                               "test",
-                               "/product/available/sdr", tmp_path / "sdr/results",
+                               "true", "/subscribe/file/available/rdr",
+                               "/product/available/sdr",
+                               tmp_path / "sdr_results",
                                "true", [],
+                               granule_time_tolerance=10,
                                ncpus=2,
                                publisher_config=os.fspath(yaml_conf))
         except TimeOut:
             pass  # probably all is fine
         else:
-            assert False  # should never get here
+            raise AssertionError()  # should never get here
             # ensure that out of date LUT updated
-        with unittest.mock.patch("cspp_runner.runner.check_lut_files",
-                                 autospec=True) as crc, \
-             unittest.mock.patch("cspp_runner.runner.update_lut_files",
-                                 autospec=True) as cru:
+        with patch("cspp_runner.runner.check_lut_files",
+                   autospec=True) as crc, \
+            patch("cspp_runner.runner.update_lut_files",
+                  autospec=True) as cru:
             crc.return_value = False
             try:
                 signal.signal(signal.SIGALRM, handler)
@@ -360,18 +423,17 @@ def test_rolling_runner(tmp_path, caplog, monkeypatch, fakemessage,
                                    "gopher://example.org/luts", "true",
                                    "gopher://example.org/ancs",
                                    os.fspath(tmp_path / "stamp_anc"),
-                                   "true", "/file/available/rdr", "earth",
-                                   "test",
+                                   "true", "/file/available/rdr",
                                    "/product/available/sdr", tmp_path / "sdr/results",
                                    "true", [], 2)
             except TimeOut:
                 pass
             else:
-                assert False
+                raise AssertionError()  # should never get here
             cru.assert_called_with(
-                    "gopher://example.org/luts",
-                    os.fspath(tmp_path / "stamp_lut"),
-                    "true")
+                "gopher://example.org/luts",
+                os.fspath(tmp_path / "stamp_lut"),
+                "true")
     assert "Dynamic ancillary data will be updated" in caplog.text
     assert "Received message data" in caplog.text
     assert "Now that SDR processing has completed" in caplog.text

--- a/cspp_runner/viirs_dr_runner.py
+++ b/cspp_runner/viirs_dr_runner.py
@@ -94,8 +94,6 @@ def main():
     subscribe_topics = OPTIONS.get('subscribe_topics').split(',')
     subscribe_topics = [topic for topic in subscribe_topics if topic]
 
-    site = OPTIONS.get('site')
-
     thr_lut_files_age_days = OPTIONS.get('threshold_lut_files_age_days', 14)
     url_jpss_remote_lut_dir = OPTIONS['url_jpss_remote_lut_dir']
     url_jpss_remote_anc_dir = OPTIONS['url_jpss_remote_anc_dir']
@@ -138,8 +136,6 @@ def main():
         anc_update_stampfile_prefix,
         OPTIONS.get("mirror_jpss_ancillary"),
         subscribe_topics,
-        site,
-        OPTIONS["mode"],
         publish_topic,
         OPTIONS["level1_home"],
         viirs_sdr_call,


### PR DESCRIPTION
Bugfix - make sure messaging is done immediately after an SDR granule is ready.

Clean up, re-factor and fix so messages are being sent immediately when SDR granule is ready

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest cspp_runner`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
